### PR TITLE
Feat/multiple istio-ingresses and gateways

### DIFF
--- a/_examples/basic/config/external-secret/external-secret.yaml
+++ b/_examples/basic/config/external-secret/external-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: external-secret                      # -- Provide external secret name
+  namespace: kube-system                     # -- Do not change this namespace field
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: external-secrets-store             # -- Provide previously created secret store name
+    kind: SecretStore
+  target:
+    name: externalsecret-data                # -- Name of secret which will contain data specified below
+    creationPolicy: Owner
+  data:
+  - secretKey: do_not_delete_this_key        # -- AWS Secret-Manager secret key
+    remoteRef:
+      key: external_secrets                  # -- Same as 'externalsecrets_manifest["secret_manager_name"]
+      property: do_not_delete_this_key       # -- AWS Secret-Manager secret key

--- a/_examples/basic/config/external-secret/override-values.yaml
+++ b/_examples/basic/config/external-secret/override-values.yaml
@@ -1,0 +1,24 @@
+## Node affinity for particular node in which labels key is "Infra-Services" and value is "true"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: "eks.amazonaws.com/nodegroup"
+          operator: In
+          values:
+          - "critical"
+
+## Using limits and requests
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 250Mi
+  requests:
+    cpu: 50m
+    memory: 150Mi
+
+podAnnotations:
+  co.elastic.logs/enabled: "true"

--- a/_examples/basic/config/external-secret/secret-store.yaml
+++ b/_examples/basic/config/external-secret/secret-store.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: external-secrets-store        # -- Provide secret store name
+  namespace: kube-system              # -- Do not change this namespace name
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1               # -- Provoide your cluster region
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa # -- Do not change this name field

--- a/_examples/basic/config/external-secret/usage.yaml
+++ b/_examples/basic/config/external-secret/usage.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu-pod
+  namespace: kube-system                       # -- keep this namespace same as ExternalSecret namespace
+  labels:
+    app: ubuntu-pod
+spec:
+  containers:
+  - image: ubuntu
+    command:
+      - "sleep"
+      - "604800"
+    imagePullPolicy: IfNotPresent
+    name: ubuntu-pod
+    env:
+      - name: USER_1                           # -- Environment variable of pod
+        valueFrom:
+          secretKeyRef:
+            name: externalsecret-data          # -- kubernetes secret name
+            key: do_not_delete_this_key        # -- Same as spec.data.secretKey field of ExternalSecret         
+            optional: false
+  restartPolicy: Always

--- a/_examples/basic/config/istio/gateway.yaml
+++ b/_examples/basic/config/istio/gateway.yaml
@@ -1,0 +1,17 @@
+# -- Make sure to use same Namespace for Gateway, Ingress & var.istio_ingress_extra_configs["namespace"], default namespace is set to `istio-system`.
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istio-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - "*.test.clouddrove.com"
+    - "test.clouddrove.com"
+    port:
+      number: 80
+      name: http
+      protocol: HTTP

--- a/_examples/basic/config/istio/ingress-internal.yaml
+++ b/_examples/basic/config/istio/ingress-internal.yaml
@@ -1,0 +1,21 @@
+# -- Make sure to use same Namespace for Ingress, Gateway & var.istio_ingress_extra_configs["namespace"], default namespace is set to `istio-system`.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: istio-ingress-internal
+  namespace: istio-system
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internal
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+spec:
+  rules:
+  - http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: istio-ingressgateway
+              port:
+                number: 80

--- a/_examples/basic/config/istio/ingress.yaml
+++ b/_examples/basic/config/istio/ingress.yaml
@@ -1,0 +1,21 @@
+# -- Make sure to use same Namespace for Ingress, Gateway & var.istio_ingress_extra_configs["namespace"], default namespace is set to `istio-system`.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: istio-ingress
+  namespace: istio-system
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+spec:
+  rules:
+  - http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: istio-ingressgateway
+              port:
+                number: 80

--- a/_examples/basic/config/istio/virtual-service.yaml
+++ b/_examples/basic/config/istio/virtual-service.yaml
@@ -1,0 +1,27 @@
+# If application will be deployed using HelmChart(ChartName=myapp) then:
+# replace `appname`      by  `{{ include "myapp.fullname" . }}`  and
+# replace `istio-system` by  `{{ include "myapp.namespace" . }}`
+
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  annotations:
+    meta.helm.sh/release-name: appname
+    meta.helm.sh/release-namespace: default
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: appname
+    app.kubernetes.io/name: appname
+  name: appname
+  namespace: default
+spec:
+  gateways:
+  - istio-system/istio-gateway
+  hosts:
+  - test.clouddrove.com
+  http:
+  - route:
+    - destination:
+        host: appname
+        port:
+          number: 80

--- a/_examples/basic/config/kiali/kiali_vs.yaml
+++ b/_examples/basic/config/kiali/kiali_vs.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  hosts:
+    - dash.test.clouddrove.com
+  gateways:
+  - istio-system/istio-gateway
+  http:
+  - route:
+    - destination:
+        host: kiali
+        port:
+          number: 20001

--- a/_examples/basic/main.tf
+++ b/_examples/basic/main.tf
@@ -47,7 +47,6 @@ module "eks" {
   cluster_name                   = "${local.name}-cluster"
   cluster_version                = local.cluster_version
   cluster_endpoint_public_access = true
-  # cluster_endpoint_private_access = true
 
   cluster_ip_family = "ipv4"
 
@@ -69,9 +68,6 @@ module "eks" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
-
-  # manage_aws_auth_configmap = true
-  # create_aws_auth_configmap = true
 
   eks_managed_node_group_defaults = {
     ami_type                   = "AL2_x86_64"

--- a/_examples/basic/variables.tf
+++ b/_examples/basic/variables.tf
@@ -4,12 +4,12 @@
 
 variable "istio_manifests" {
   type = object({
-    istio_ingress_manifest_file_path = string
-    istio_gateway_manifest_file_path = string
+    istio_ingress_manifest_file_path = list(any)
+    istio_gateway_manifest_file_path = list(any)
   })
   default = {
-    istio_ingress_manifest_file_path = "./config/istio/ingress.yaml"
-    istio_gateway_manifest_file_path = "./config/istio/gateway.yaml"
+    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml","./config/istio/ingress-internal.yaml"]
+    istio_gateway_manifest_file_path = ["./config/istio/gateway.yaml"]
   }
   description = "Path to yaml manifests to create Ingress and Gateway with specified host"
 }

--- a/_examples/basic/variables.tf
+++ b/_examples/basic/variables.tf
@@ -8,7 +8,7 @@ variable "istio_manifests" {
     istio_gateway_manifest_file_path = list(any)
   })
   default = {
-    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml","./config/istio/ingress-internal.yaml"]
+    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml", "./config/istio/ingress-internal.yaml"]
     istio_gateway_manifest_file_path = ["./config/istio/gateway.yaml"]
   }
   description = "Path to yaml manifests to create Ingress and Gateway with specified host"

--- a/_examples/complete/config/istio/ingress-internal.yaml
+++ b/_examples/complete/config/istio/ingress-internal.yaml
@@ -1,0 +1,21 @@
+# -- Make sure to use same Namespace for Ingress, Gateway & var.istio_ingress_extra_configs["namespace"], default namespace is set to `istio-system`.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: istio-ingress-internal
+  namespace: istio-system
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internal
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+spec:
+  rules:
+  - http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: istio-ingress
+              port:
+                number: 80

--- a/_examples/complete/variables.tf
+++ b/_examples/complete/variables.tf
@@ -9,7 +9,7 @@ variable "istio_manifests" {
     istio_gateway_manifest_file_path = list(any)
   })
   default = {
-    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml","./config/istio/ingress-internal.yaml"]
+    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml", "./config/istio/ingress-internal.yaml"]
     istio_gateway_manifest_file_path = ["./config/istio/gateway.yaml"]
   }
   description = "Path to yaml manifests to create Ingress and Gateway with specified host"

--- a/_examples/complete/variables.tf
+++ b/_examples/complete/variables.tf
@@ -5,13 +5,14 @@
 # ------------------ ISTIO INGRESS ---------------------------------------------
 variable "istio_manifests" {
   type = object({
-    istio_ingress_manifest_file_path = string
-    istio_gateway_manifest_file_path = string
+    istio_ingress_manifest_file_path = list(any)
+    istio_gateway_manifest_file_path = list(any)
   })
   default = {
-    istio_ingress_manifest_file_path = "./config/istio/ingress.yaml"
-    istio_gateway_manifest_file_path = "./config/istio/gateway.yaml"
+    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml","./config/istio/ingress-internal.yaml"]
+    istio_gateway_manifest_file_path = ["./config/istio/gateway.yaml"]
   }
+  description = "Path to yaml manifests to create Ingress and Gateway with specified host"
 }
 
 #-----------KAILI DASHBOARD-----------------------------------------------------

--- a/addons/istio-ingress/main.tf
+++ b/addons/istio-ingress/main.tf
@@ -28,12 +28,14 @@ module "istio_ingress" {
 }
 
 resource "kubectl_manifest" "istio_ingress_manifest" {
+  count      = length(var.istio_manifests.istio_ingress_manifest_file_path)
   depends_on = [module.istio_ingress]
-  yaml_body  = file(var.istio_manifests.istio_ingress_manifest_file_path)
+  yaml_body  = file("${var.istio_manifests.istio_ingress_manifest_file_path[count.index]}")
 }
 
 resource "kubectl_manifest" "istio_gateway_manifest" {
+  count      = length(var.istio_manifests.istio_gateway_manifest_file_path)
   depends_on = [kubectl_manifest.istio_ingress_manifest]
-  yaml_body  = file(var.istio_manifests.istio_gateway_manifest_file_path)
+  yaml_body  = file("${var.istio_manifests.istio_gateway_manifest_file_path[count.index]}")
 }
 

--- a/addons/istio-ingress/variables.tf
+++ b/addons/istio-ingress/variables.tf
@@ -27,8 +27,8 @@ variable "addon_context" {
 
 variable "istio_manifests" {
   type = object({
-    istio_ingress_manifest_file_path = string
-    istio_gateway_manifest_file_path = string
+    istio_ingress_manifest_file_path = list(any)
+    istio_gateway_manifest_file_path = list(any)
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -176,12 +176,12 @@ variable "istio_ingress_helm_config" {
 
 variable "istio_manifests" {
   type = object({
-    istio_ingress_manifest_file_path = string
-    istio_gateway_manifest_file_path = string
+    istio_ingress_manifest_file_path = list(any)
+    istio_gateway_manifest_file_path = list(any)
   })
   default = {
-    istio_ingress_manifest_file_path = ""
-    istio_gateway_manifest_file_path = ""
+    istio_ingress_manifest_file_path = [""]
+    istio_gateway_manifest_file_path = [""]
   }
 }
 


### PR DESCRIPTION
- Previously we can only create 1 istio-ingress when calling module, to create another ingress we need to call the same module again.
- I have added a feature where user can pass more than 1 path of ingress.yaml file, did the same for gateway.yaml.