### PR TITLE
Feat: :rocket: use external-secret in multiple namespaces

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,113 @@
+plugin "aws" {
+    enabled = true
+    version = "0.21.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+config {
+#Enables module inspection
+module = false
+force = false
+}
+
+# Required that all AWS resources have specified tags.
+rule "aws_resource_missing_tags" {
+  enabled = true
+  tags = [
+    "Name",
+    "Environment",
+  ]
+}
+
+# Disallow deprecated (0.11-style) interpolation
+rule "terraform_deprecated_interpolation" {
+enabled = true
+}
+
+# Disallow legacy dot index syntax.
+rule "terraform_deprecated_index" {
+enabled = true
+}
+
+# Disallow variables, data sources, and locals that are declared but never used.
+rule "terraform_unused_declarations" {
+enabled = true
+}
+
+# Disallow // comments in favor of #.
+rule "terraform_comment_syntax" {
+enabled = false
+}
+
+# Disallow output declarations without description.
+rule "terraform_documented_outputs" {
+enabled = true
+}
+
+# Disallow variable declarations without description.
+rule "terraform_documented_variables" {
+enabled = true
+}
+
+# Disallow variable declarations without type.
+rule "terraform_typed_variables" {
+enabled = true
+}
+
+# Disallow specifying a git or mercurial repository as a module source without pinning to a version.
+rule "terraform_module_pinned_source" {
+enabled = true
+}
+
+# Enforces naming conventions
+rule "terraform_naming_convention" {
+enabled = true
+
+#Require specific naming structure
+variable {
+format = "snake_case"
+}
+
+locals {
+format = "snake_case"
+}
+
+output {
+format = "snake_case"
+}
+
+#Allow any format
+resource {
+format = "none"
+}
+
+module {
+format = "none"
+}
+
+data {
+format = "none"
+}
+
+}
+
+# Disallow terraform declarations without require_version.
+# rule "terraform_required_version" {
+# enabled = true
+# }
+
+# Require that all providers have version constraints through required_providers.
+rule "terraform_required_providers" {
+enabled = true
+}
+
+# Ensure that a module complies with the Terraform Standard Module Structure
+rule "terraform_standard_module_structure" {
+enabled = true
+}
+
+# terraform.workspace should not be used with a "remote" backend with remote execution.
+rule "terraform_workspace_remote" {
+enabled = true
+}
+

--- a/_examples/basic/main.tf
+++ b/_examples/basic/main.tf
@@ -174,12 +174,11 @@ module "addons" {
   velero                       = true
 
   # -- Addons with mandatory variable
-  istio_ingress             = true
-  istio_manifests           = var.istio_manifests
-  kiali_server              = true
-  kiali_manifests           = var.kiali_manifests
-  external_secrets          = true
-  externalsecrets_manifests = var.externalsecrets_manifests
+  istio_ingress    = true
+  istio_manifests  = var.istio_manifests
+  kiali_server     = true
+  kiali_manifests  = var.kiali_manifests
+  external_secrets = true
 
   # -- Extra helm_release attributes
   velero_extra_configs = var.velero_extra_configs

--- a/_examples/basic/variables.tf
+++ b/_examples/basic/variables.tf
@@ -24,20 +24,6 @@ variable "kiali_manifests" {
   description = "Path to VirtualService manifest for kiali-dashboard"
 }
 
-variable "externalsecrets_manifests" {
-  type = object({
-    secret_store_manifest_file_path     = string
-    external_secrets_manifest_file_path = string
-    secret_manager_name                 = string
-  })
-  default = {
-    secret_store_manifest_file_path     = "./config/external-secret/secret-store.yaml"
-    external_secrets_manifest_file_path = "./config/external-secret/external-secret.yaml"
-    secret_manager_name                 = "external_secrets"
-  }
-  description = "yaml manifest file path to create ExternalSecret, SecretStore and custome SecretManger name"
-}
-
 #------------ EXTRA CONFIGS -----------
 variable "velero_extra_configs" {
   type = any

--- a/_examples/complete/config/istio/gateway-internal.yaml
+++ b/_examples/complete/config/istio/gateway-internal.yaml
@@ -1,0 +1,17 @@
+# -- Make sure to use same Namespace for Gateway, Ingress & var.istio_ingress_extra_configs["namespace"], default namespace is set to `istio-system`.
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istio-gateway-internal
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingress-internal
+  servers:
+  - hosts:
+    - "*.test.clouddrove.com"
+    - "test.clouddrove.com"
+    port:
+      number: 80
+      name: http
+      protocol: HTTP

--- a/_examples/complete/config/istio/ingress-internal.yaml
+++ b/_examples/complete/config/istio/ingress-internal.yaml
@@ -16,6 +16,6 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name: istio-ingress
+              name: istio-ingress-internal
               port:
                 number: 80

--- a/_examples/complete/main.tf
+++ b/_examples/complete/main.tf
@@ -213,7 +213,7 @@ module "addons" {
   velero_extra_configs                       = var.velero_extra_configs
   new_relic_extra_configs                    = var.new_relic_extra_configs
   kube_state_metrics_extra_configs           = var.kube_state_metrics_extra_configs
-  keda_extra_configs                         = var.keda_extra_configs    
+  keda_extra_configs                         = var.keda_extra_configs
 
   external_secrets_extra_configs = {
     secret_manager_name = "external_secrets_addon"

--- a/_examples/complete/main.tf
+++ b/_examples/complete/main.tf
@@ -160,14 +160,14 @@ module "addons" {
   aws_efs_csi_driver           = true
   aws_ebs_csi_driver           = true
   kube_state_metrics           = true
-  # karpenter                    = false    # -- Set to `false` or comment line to Uninstall Karpenter if installed using terraform.
-  calico_tigera = true
-  new_relic     = true
-  kubeclarity   = true
-  ingress_nginx = true
-  fluent_bit    = true
-  velero        = true
-  keda          = true
+  karpenter                    = false # -- Set to `false` or comment line to Uninstall Karpenter if installed using terraform.
+  calico_tigera                = true
+  new_relic                    = true
+  kubeclarity                  = true
+  ingress_nginx                = true
+  fluent_bit                   = true
+  velero                       = true
+  keda                         = true
 
   # -- Addons with mandatory variable
   istio_ingress    = true
@@ -216,14 +216,13 @@ module "addons" {
   keda_extra_configs                         = var.keda_extra_configs
 
   external_secrets_extra_configs = {
-    secret_manager_name = "external_secrets_addon"
     irsa_assume_role_policy = jsonencode({
       "Version" : "2012-10-17",
       "Statement" : [
         {
           "Effect" : "Allow",
           "Principal" : {
-            "Federated" : "${module.eks.oidc_provider_arn}"
+            "Federated" : module.eks.oidc_provider_arn
           },
           "Action" : "sts:AssumeRoleWithWebIdentity",
           "Condition" : {
@@ -234,8 +233,20 @@ module "addons" {
         }
       ]
     })
+    secret_manager_name = "external_secrets_addon"
   }
 
   # -- Custom IAM Policy Json for Addon's ServiceAccount
   cluster_autoscaler_iampolicy_json_content = file("./custom-iam-policies/cluster-autoscaler.json")
+}
+
+module "addons-internal" {
+  source = "../../"
+
+  depends_on       = [module.eks]
+  eks_cluster_name = module.eks.cluster_name
+
+  istio_ingress               = true
+  istio_manifests             = var.istio_manifests_internal
+  istio_ingress_extra_configs = var.istio_ingress_extra_configs_internal
 }

--- a/_examples/complete/outputs.tf
+++ b/_examples/complete/outputs.tf
@@ -14,9 +14,5 @@ output "update_kubeconfig" {
 }
 
 output "velero_post_installation" {
-  value = <<EOF
-Once velero server is up and running you need the client before you can use it
-1. wget https://github.com/vmware-tanzu/velero/releases/download/v1.11.1/velero-v1.11.1-darwin-amd64.tar.gz
-2. tar -xvf velero-v1.11.1-darwin-amd64.tar.gz -C velero-client  
-  EOF  
+  value = indent(2, "Once velero server is up and running you need the client before you can use it - \n  1. wget https://github.com/vmware-tanzu/velero/releases/download/v1.11.1/velero-v1.11.1-darwin-amd64.tar.gz \n  2. tar -xvf velero-v1.11.1-darwin-amd64.tar.gz -C velero-client")
 }

--- a/_examples/complete/providers.tf
+++ b/_examples/complete/providers.tf
@@ -38,3 +38,5 @@ data "aws_eks_cluster" "eks_cluster" {
   depends_on = [module.eks.cluster_id]
 }
 data "aws_availability_zones" "available" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/_examples/complete/providers.tf
+++ b/_examples/complete/providers.tf
@@ -38,5 +38,3 @@ data "aws_eks_cluster" "eks_cluster" {
   depends_on = [module.eks.cluster_id]
 }
 data "aws_availability_zones" "available" {}
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}

--- a/_examples/complete/variables.tf
+++ b/_examples/complete/variables.tf
@@ -2,17 +2,150 @@
 # Variables
 # ------------------------------------------------------------------------------
 
+# ------------------ METRICS SERVER --------------------------------------------
+variable "metrics_server_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ CLUSTER AUTOSCALER ----------------------------------------
+variable "cluster_autoscaler_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ KARPENTER -------------------------------------------------
+variable "karpenter_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ LOAD BALANCER CONTROLLER ----------------------------------
+variable "aws_load_balancer_controller_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ NODE TERMINATION HANDLER ----------------------------------
+variable "aws_node_termination_handler_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ EFS CSI DRIVER --------------------------------------------
+variable "aws_efs_csi_driver_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ EBS CSI DRIVER --------------------------------------------
+variable "aws_ebs_csi_driver_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ CALICO ----------------------------------------------------
+variable "calico_tigera_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ NGINX INGRESS ---------------------------------------------
+variable "ingress_nginx_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ KUBECLARITY -----------------------------------------------
+variable "kubeclarity_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ FLUENT-BIT ------------------------------------------------
+variable "fluent_bit_extra_configs" {
+  type = any
+  default = {
+    atomic  = true
+    timeout = 300
+  }
+}
+
+# ------------------ VELERO ----------------------------------------------------
+variable "velero_extra_configs" {
+  type = any
+  default = {
+    timeout     = 300
+    atomic      = true
+    bucket_name = "velero-addons"
+  }
+}
+
+# ------------------ NEW-RELIC -------------------------------------------------
+variable "new_relic_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ KUBE STATE METRICS ----------------------------------------
+variable "kube_state_metrics_extra_configs" {
+  type    = any
+  default = {}
+}
+
+# ------------------ KEDA -----------------------------------------------------
+variable "keda_extra_configs" {
+  type    = any
+  default = {}
+}
+
 # ------------------ ISTIO INGRESS ---------------------------------------------
+# -- INTERNET FACING --------------
 variable "istio_manifests" {
   type = object({
     istio_ingress_manifest_file_path = list(any)
     istio_gateway_manifest_file_path = list(any)
   })
   default = {
-    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml", "./config/istio/ingress-internal.yaml"]
+    istio_ingress_manifest_file_path = ["./config/istio/ingress.yaml"]
     istio_gateway_manifest_file_path = ["./config/istio/gateway.yaml"]
   }
   description = "Path to yaml manifests to create Ingress and Gateway with specified host"
+}
+
+variable "istio_ingress_extra_configs" {
+  type = any
+  default = {
+    name             = "istio-ingress"
+    namespace        = "istio-system"
+    create_namespace = true
+  }
+}
+
+# -- INTERNAL ---------------------
+variable "istio_manifests_internal" {
+  type = object({
+    istio_ingress_manifest_file_path = list(any)
+    istio_gateway_manifest_file_path = list(any)
+  })
+  default = {
+    istio_ingress_manifest_file_path = ["./config/istio/ingress-internal.yaml"]
+    istio_gateway_manifest_file_path = ["./config/istio/gateway-internal.yaml"]
+  }
+  description = "Path to yaml manifests to create Internal Ingress and Gateway with specified host"
+}
+
+variable "istio_ingress_extra_configs_internal" {
+  type = any
+  default = {
+    name                   = "istio-ingress-internal"
+    namespace              = "istio-system"
+    istiobase_release_name = "base-internal"
+    istiod_release_name    = "istiod-internal"
+    create_namespace       = true
+    install_istiobase      = false
+    install_istiod         = false
+  }
 }
 
 #-----------KAILI DASHBOARD-----------------------------------------------------
@@ -25,99 +158,7 @@ variable "kiali_manifests" {
   }
 }
 
-#--------------OVERRIDE HELM RELEASE ATTRIBUTES --------------------------------
-variable "metrics_server_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "cluster_autoscaler_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "karpenter_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "aws_load_balancer_controller_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "aws_node_termination_handler_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "aws_efs_csi_driver_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "aws_ebs_csi_driver_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "calico_tigera_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "istio_ingress_extra_configs" {
-  type = any
-  default = {
-    name             = "istio-ingress"
-    namespace        = "istio-system"
-    create_namespace = true
-  }
-}
-
 variable "kiali_server_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "ingress_nginx_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "kubeclarity_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "fluent_bit_extra_configs" {
-  type = any
-  default = {
-    atomic  = true
-    timeout = 300
-  }
-}
-
-variable "velero_extra_configs" {
-  type = any
-  default = {
-    timeout     = 300
-    atomic      = true
-    bucket_name = "velero-addons"
-  }
-}
-
-variable "new_relic_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "kube_state_metrics_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "keda_extra_configs" {
   type    = any
   default = {}
 }

--- a/_examples/complete/variables.tf
+++ b/_examples/complete/variables.tf
@@ -25,20 +25,6 @@ variable "kiali_manifests" {
   }
 }
 
-# ------------------ EXTERNAL SECRETS ------------------------------------------
-variable "externalsecrets_manifests" {
-  type = object({
-    secret_store_manifest_file_path     = string
-    external_secrets_manifest_file_path = string
-    secret_manager_name                 = string
-  })
-  default = {
-    secret_store_manifest_file_path     = "./config/external-secret/secret-store.yaml"
-    external_secrets_manifest_file_path = "./config/external-secret/external-secret.yaml"
-    secret_manager_name                 = "external_secrets"
-  }
-}
-
 #--------------OVERRIDE HELM RELEASE ATTRIBUTES --------------------------------
 variable "metrics_server_extra_configs" {
   type    = any
@@ -90,11 +76,6 @@ variable "istio_ingress_extra_configs" {
 }
 
 variable "kiali_server_extra_configs" {
-  type    = any
-  default = {}
-}
-
-variable "external_secrets_extra_configs" {
   type    = any
   default = {}
 }

--- a/addons/external-secrets/outputs.tf
+++ b/addons/external-secrets/outputs.tf
@@ -1,7 +1,3 @@
-output "secret_manager_name" {
-  value = var.externalsecrets_manifests.secret_manager_name
-}
-
 output "service_account" {
   value = "${local.name}-sa"
 }

--- a/addons/external-secrets/variables.tf
+++ b/addons/external-secrets/variables.tf
@@ -40,9 +40,3 @@ variable "external_secrets_extra_configs" {
   type        = any
   default     = {}
 }
-
-variable "irsa_assume_role_policy" {
-  description = "Custom Trust Relationship policy for IAM Role"
-  type        = any
-  default     = null
-}

--- a/addons/external-secrets/variables.tf
+++ b/addons/external-secrets/variables.tf
@@ -35,16 +35,14 @@ variable "addon_context" {
   })
 }
 
-variable "externalsecrets_manifests" {
-  type = object({
-    secret_store_manifest_file_path     = string
-    external_secrets_manifest_file_path = string
-    secret_manager_name                 = string
-  })
-}
-
 variable "external_secrets_extra_configs" {
   description = "Override attributes of helm_release terraform resource"
   type        = any
   default     = {}
+}
+
+variable "irsa_assume_role_policy" {
+  description = "Custom Trust Relationship policy for IAM Role"
+  type        = any
+  default     = null
 }

--- a/addons/helm/main.tf
+++ b/addons/helm/main.tf
@@ -76,4 +76,5 @@ module "irsa" {
   irsa_iam_permissions_boundary     = lookup(var.addon_context, "irsa_iam_permissions_boundary", null)
   eks_oidc_provider_arn             = lookup(var.irsa_config, "eks_oidc_provider_arn", "")
   account_id                        = lookup(var.irsa_config, "account_id", "")
+  irsa_assume_role_policy           = var.irsa_assume_role_policy
 }

--- a/addons/helm/variables.tf
+++ b/addons/helm/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
   description = "Input configuration for the addon"
   type        = any
 }
+
+variable "irsa_assume_role_policy" {
+  description = "Custom Trust Relationship policy for IAM Role"
+  type        = any
+  default     = null
+}

--- a/addons/helm/variables.tf
+++ b/addons/helm/variables.tf
@@ -29,7 +29,7 @@ variable "irsa_config" {
 }
 
 variable "addon_context" {
-  description = "Input configuration for the addon"
+  description = "IRSA Input configuration for the addon"
   type        = any
 }
 

--- a/addons/istio-ingress/locals.tf
+++ b/addons/istio-ingress/locals.tf
@@ -1,7 +1,7 @@
 locals {
   istio_base = {
     helm_config = {
-      name             = "base"
+      name             = try(var.istio_ingress_extra_configs.istiobase_release_name, "base")
       chart            = "base"
       repository       = "https://istio-release.storage.googleapis.com/charts"
       version          = "1.18.0"
@@ -13,7 +13,7 @@ locals {
 
   istiod = {
     helm_config = {
-      name             = "istiod"
+      name             = try(var.istio_ingress_extra_configs.istiod_release_name, "istiod")
       chart            = "istiod"
       repository       = "https://istio-release.storage.googleapis.com/charts"
       version          = "1.18.0"

--- a/addons/istio-ingress/main.tf
+++ b/addons/istio-ingress/main.tf
@@ -1,5 +1,6 @@
 module "istio_base" {
   source = "../helm"
+  count  = try(var.istio_ingress_extra_configs.install_istiobase, true) ? 1 : 0
 
   manage_via_gitops = var.manage_via_gitops
   helm_config       = local.istio_base.helm_config
@@ -9,6 +10,7 @@ module "istio_base" {
 
 module "istiod" {
   source = "../helm"
+  count  = try(var.istio_ingress_extra_configs.install_istiod, true) ? 1 : 0
 
   manage_via_gitops = var.manage_via_gitops
   helm_config       = local.istiod.helm_config

--- a/data.tf
+++ b/data.tf
@@ -2,7 +2,6 @@ data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 data "aws_eks_cluster" "eks_cluster" {
-  # this makes downstream resources wait for data plane to be ready
   name = var.eks_cluster_name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,6 @@ module "external_secrets" {
   addon_context                  = local.addon_context
   eks_cluster_name               = data.aws_eks_cluster.eks_cluster.name
   account_id                     = data.aws_caller_identity.current.account_id
-  externalsecrets_manifests      = var.externalsecrets_manifests
   external_secrets_extra_configs = var.external_secrets_extra_configs
 }
 

--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role" "irsa" {
 
   name        = try(var.irsa_iam_role_name, "${var.kubernetes_service_account}-iam-role")
   description = "AWS IAM Role for the Kubernetes service account ${var.kubernetes_service_account}."
-  assume_role_policy = jsonencode({
+  assume_role_policy = var.irsa_assume_role_policy != null ? var.irsa_assume_role_policy : jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
       {

--- a/modules/irsa/variables.tf
+++ b/modules/irsa/variables.tf
@@ -65,3 +65,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "irsa_assume_role_policy" {
+  description = "Custom Trust Relationship policy for IAM Role"
+  type        = any
+  default     = null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -111,9 +111,6 @@ output "calico_tigera_repository" {
 }
 
 #----------- EXTERNAL SECRETS ------------------
-output "external_secrets_secret_manager_name" {
-  value = module.external_secrets[*].secret_manager_name
-}
 output "external_secrets_service_account" {
   value = module.external_secrets[*].service_account
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,211 +1,271 @@
 #----------- METRIC SERVER ---------------------
 output "metrics_server_namespace" {
-  value = module.metrics_server[*].namespace
+  value       = module.metrics_server[*].namespace
+  description = "Namespace where metrics-server is installed"
 }
 output "metrics_server_chart_version" {
-  value = module.metrics_server[*].chart_version
+  value       = module.metrics_server[*].chart_version
+  description = "chart version used for metrics-server helmchart"
 }
 output "metrics_server_repository" {
-  value = module.metrics_server[*].repository
+  value       = module.metrics_server[*].repository
+  description = "helm repository url of metrics-server"
 }
 
 #----------- CLUSTER AUTOSCALER ----------------
 output "cluster_autoscaler_service_account" {
-  value = module.cluster_autoscaler[*].service_account
+  value       = module.cluster_autoscaler[*].service_account
+  description = "name of cluster-autoscaler service-account"
 }
 output "cluster_autoscaler_iam_policy" {
-  value = module.cluster_autoscaler[*].iam_policy
+  value       = module.cluster_autoscaler[*].iam_policy
+  description = "IAM Policy name used in cluster-autoscaler irsa"
 }
 output "cluster_autoscaler_namespace" {
-  value = module.cluster_autoscaler[*].namespace
+  value       = module.cluster_autoscaler[*].namespace
+  description = "Namespace where cluster-autoscaler is installed"
 }
 output "cluster_autoscaler_chart_version" {
-  value = module.cluster_autoscaler[*].chart_version
+  value       = module.cluster_autoscaler[*].chart_version
+  description = "chart version used for cluster-autoscaler helmchart"
 }
 output "cluster_autoscaler_repository" {
-  value = module.cluster_autoscaler[*].repository
+  value       = module.cluster_autoscaler[*].repository
+  description = "helm repository url of cluster-autoscaler"
 }
 
 #----------- AWS EFS CSI DRIVER ----------------
 output "aws_efs_csi_driver_service_account" {
-  value = module.aws_efs_csi_driver[*].service_account
+  value       = module.aws_efs_csi_driver[*].service_account
+  description = "name of aws-efs-csi-driver service-account"
 }
 output "aws_efs_csi_driver_iam_policy" {
-  value = module.aws_efs_csi_driver[*].iam_policy
+  value       = module.aws_efs_csi_driver[*].iam_policy
+  description = "IAM Policy name used in aws-efs-csi-driver irsa"
 }
 output "aws_efs_csi_driver_namespace" {
-  value = module.aws_efs_csi_driver[*].namespace
+  value       = module.aws_efs_csi_driver[*].namespace
+  description = "Namespace where aws-efs-csi-driver is installed"
 }
 output "aws_efs_csi_driver_chart_version" {
-  value = module.aws_efs_csi_driver[*].chart_version
+  value       = module.aws_efs_csi_driver[*].chart_version
+  description = "chart version used for aws-efs-csi-driver helmchart"
 }
 output "aws_efs_csi_driver_repository" {
-  value = module.aws_efs_csi_driver[*].repository
+  value       = module.aws_efs_csi_driver[*].repository
+  description = "helm repository url of aws-efs-csi-driver"
 }
 
 #----------- AWS EBS CSI DRIVER ----------------
 output "aws_ebs_csi_driver_service_account" {
-  value = module.aws_ebs_csi_driver[*].service_account
+  value       = module.aws_ebs_csi_driver[*].service_account
+  description = "name of aws-ebs-csi-driver service-account"
 }
 output "aws_ebs_csi_driver_iam_policy" {
-  value = module.aws_ebs_csi_driver[*].iam_policy
+  value       = module.aws_ebs_csi_driver[*].iam_policy
+  description = "IAM Policy name used in aws-ebs-csi-driver irsa"
 }
 output "aws_ebs_csi_driver_namespace" {
-  value = module.aws_ebs_csi_driver[*].namespace
+  value       = module.aws_ebs_csi_driver[*].namespace
+  description = "Namespace where aws-ebs-csi-driver is installed"
 }
 output "aws_ebs_csi_driver_chart_version" {
-  value = module.aws_ebs_csi_driver[*].chart_version
+  value       = module.aws_ebs_csi_driver[*].chart_version
+  description = "chart version used for aws-ebs-csi-driver helmchart"
 }
 output "aws_ebs_csi_driver_repository" {
-  value = module.aws_ebs_csi_driver[*].repository
+  value       = module.aws_ebs_csi_driver[*].repository
+  description = "helm repository url of aws-ebs-csi-driver"
 }
 
 #----------- KARPENTER -------------------------
 output "karpenter_service_account" {
-  value = module.karpenter[*].service_account
+  value       = module.karpenter[*].service_account
+  description = "name of karpenter service-account"
 }
 output "karpenter_iam_policy" {
-  value = module.karpenter[*].iam_policy
+  value       = module.karpenter[*].iam_policy
+  description = "IAM Policy name used in karpenter irsa"
 }
 output "karpenter_namespace" {
-  value = module.karpenter[*].namespace
+  value       = module.karpenter[*].namespace
+  description = "Namespace where karpenter is installed"
 }
 output "karpenter_chart_version" {
-  value = module.karpenter[*].chart_version
+  value       = module.karpenter[*].chart_version
+  description = "chart version used for karpenter helmchart"
 }
 output "karpenter_repository" {
-  value = module.karpenter[*].repository
+  value       = module.karpenter[*].repository
+  description = "helm repository url of karpenter"
 }
 
 #----------- ISTIO INGRESS ---------------------
 output "istio_ingress_namespace" {
-  value = module.istio_ingress[*].namespace
+  value       = module.istio_ingress[*].namespace
+  description = "Namespace where istio-ingress is installed"
 }
 output "istio_ingress_chart_version" {
-  value = module.istio_ingress[*].chart_version
+  value       = module.istio_ingress[*].chart_version
+  description = "chart version used for istio-ingress helmchart"
 }
 output "istio_ingress_repository" {
-  value = module.istio_ingress[*].repository
+  value       = module.istio_ingress[*].repository
+  description = "helm repository url of istio-ingress"
 }
 
 #----------- KAILI DASHBOARD -------------------
 output "kiali_server_namespace" {
-  value = module.kiali_server[*].namespace
+  value       = module.kiali_server[*].namespace
+  description = "Namespace where kiali-server is installed"
 }
 output "kiali_server_chart_version" {
-  value = module.kiali_server[*].chart_version
+  value       = module.kiali_server[*].chart_version
+  description = "chart version used for kiali-server helmchart"
 }
 output "kiali_server_repository" {
-  value = module.kiali_server[*].repository
+  value       = module.kiali_server[*].repository
+  description = "helm repository url of kiali-server"
 }
 
 #----------- CALICO TOGERA ---------------------
 output "calico_tigera_namespace" {
-  value = module.calico_tigera[*].namespace
+  value       = module.calico_tigera[*].namespace
+  description = "Namespace where calico-tigera is installed"
 }
 output "calico_tigera_chart_version" {
-  value = module.calico_tigera[*].chart_version
+  value       = module.calico_tigera[*].chart_version
+  description = "chart version used for calico-tigera helmchart"
 }
 output "calico_tigera_repository" {
-  value = module.calico_tigera[*].repository
+  value       = module.calico_tigera[*].repository
+  description = "helm repository url of calico-tigera"
 }
 
 #----------- EXTERNAL SECRETS ------------------
 output "external_secrets_service_account" {
-  value = module.external_secrets[*].service_account
+  value       = module.external_secrets[*].service_account
+  description = "name of external-secrets service-account"
 }
 output "external_secrets_namespace" {
-  value = module.external_secrets[*].namespace
+  value       = module.external_secrets[*].namespace
+  description = "Namespace where external-secrets is installed"
 }
 output "external_secrets_chart_version" {
-  value = module.ingress_nginx[*].chart_version
+  value       = module.ingress_nginx[*].chart_version
+  description = "chart version used for external-secrets helmchart"
 }
 output "external_secrets_repository" {
-  value = module.ingress_nginx[*].repository
+  value       = module.ingress_nginx[*].repository
+  description = "helm repository url of external-secrets"
 }
 
 #----------- INGRESS NGINX ---------------------
 output "ingress_nginx_namespace" {
-  value = module.ingress_nginx[*].namespace
+  value       = module.ingress_nginx[*].namespace
+  description = "Namespace where ingress-nginx is installed"
 }
 output "ingress_nginx_chart_version" {
-  value = module.ingress_nginx[*].chart_version
+  value       = module.ingress_nginx[*].chart_version
+  description = "chart version used for ingress-nginx helmchart"
 }
 output "ingress_nginx_repository" {
-  value = module.ingress_nginx[*].repository
+  value       = module.ingress_nginx[*].repository
+  description = "helm repository url of ingress-nginx"
 }
 
 #----------- KUBECLARITY -----------------------
 output "kubeclarity_namespace" {
-  value = module.kubeclarity[*].namespace
+  value       = module.kubeclarity[*].namespace
+  description = "Namespace where kubeclarity is installed"
 }
 output "kubeclarity_chart_version" {
-  value = module.kubeclarity[*].chart_version
+  value       = module.kubeclarity[*].chart_version
+  description = "chart version used for kubeclarity helmchart"
 }
 output "kubeclarity_repository" {
-  value = module.kubeclarity[*].repository
+  value       = module.kubeclarity[*].repository
+  description = "helm repository url of kubeclarity"
 }
 
 #----------- AWS LOAD BALANCER CONTROLLER ----------------
 output "aws_load_balancer_controller_service_account" {
-  value = module.aws_load_balancer_controller[*].service_account
+  value       = module.aws_load_balancer_controller[*].service_account
+  description = "name of aws-load-balancer-controller service-account"
 }
 output "aws_load_balancer_controller_iam_policy" {
-  value = module.aws_load_balancer_controller[*].iam_policy
+  value       = module.aws_load_balancer_controller[*].iam_policy
+  description = "IAM Policy name used in aws-load-balancer-controller irsa"
 }
 output "aws_load_balancer_controller_namespace" {
-  value = module.aws_load_balancer_controller[*].namespace
+  value       = module.aws_load_balancer_controller[*].namespace
+  description = "Namespace where aws-load-balancer-controller is installed"
 }
 output "aws_load_balancer_controller_chart_version" {
-  value = module.aws_load_balancer_controller[*].chart_version
+  value       = module.aws_load_balancer_controller[*].chart_version
+  description = "chart version used for aws-load-balancer-controller helmchart"
 }
 output "aws_load_balancer_controller_repository" {
-  value = module.aws_load_balancer_controller[*].repository
+  value       = module.aws_load_balancer_controller[*].repository
+  description = "helm repository url of aws-load-balancer-controller"
 }
 
 #----------- FLUENT-BIT ----------------
 output "fluent_bit_service_account" {
-  value = module.fluent_bit[*].service_account
+  value       = module.fluent_bit[*].service_account
+  description = "name of fluent-bit service-account"
 }
 output "fluent_bit_iam_policy" {
-  value = module.fluent_bit[*].iam_policy
+  value       = module.fluent_bit[*].iam_policy
+  description = "IAM Policy name used in fluent-bit irsa"
 }
 output "fluent_bit_namespace" {
-  value = module.fluent_bit[*].namespace
+  value       = module.fluent_bit[*].namespace
+  description = "Namespace where fluent-bit is installed"
 }
 output "fluent_bit_chart_version" {
-  value = module.fluent_bit[*].chart_version
+  value       = module.fluent_bit[*].chart_version
+  description = "chart version used for fluent-bit helmchart"
 }
 output "fluent_bit_repository" {
-  value = module.fluent_bit[*].repository
+  value       = module.fluent_bit[*].repository
+  description = "helm repository url of fluent-bit"
 }
 
 #----------- NEW-RELIC ------------------------
 output "new_relic_namespace" {
-  value = module.new_relic[*].namespace
+  value       = module.new_relic[*].namespace
+  description = "Namespace where new-relic is installed"
 }
 output "new_relic_chart_version" {
-  value = module.new_relic[*].chart_version
+  value       = module.new_relic[*].chart_version
+  description = "chart version used for new-relic helmchart"
 }
 output "new_relic_repository" {
-  value = module.new_relic[*].repository
+  value       = module.new_relic[*].repository
+  description = "helm repository url of new-relic"
 }
 
 #----------- VELERO ----------------
 output "velero_service_account" {
-  value = module.velero[*].service_account
+  value       = module.velero[*].service_account
+  description = "name of velero service-account"
 }
 output "velero_iam_policy" {
-  value = module.velero[*].iam_policy
+  value       = module.velero[*].iam_policy
+  description = "IAM Policy name used in velero irsa"
 }
 output "velero_namespace" {
-  value = module.velero[*].namespace
+  value       = module.velero[*].namespace
+  description = "Namespace where velero is installed"
 }
 output "velero_chart_version" {
-  value = module.velero[*].chart_version
+  value       = module.velero[*].chart_version
+  description = "chart version used for velero helmchart"
 }
 output "velero_repository" {
-  value = module.velero[*].repository
+  value       = module.velero[*].repository
+  description = "helm repository url of velero"
 }
 
 #----------- KUBE-STATE-METRICS ------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -252,19 +252,6 @@ variable "external_secrets_helm_config" {
   default     = null
 }
 
-variable "externalsecrets_manifests" {
-  type = object({
-    secret_store_manifest_file_path     = string
-    external_secrets_manifest_file_path = string
-    secret_manager_name                 = string
-  })
-  default = {
-    secret_store_manifest_file_path     = ""
-    external_secrets_manifest_file_path = ""
-    secret_manager_name                 = "addon-external_secrets"
-  }
-}
-
 variable "external_secrets_extra_configs" {
   description = "Override attributes of helm_release terraform resource"
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -338,28 +338,33 @@ variable "kube_state_metrics_extra_configs" {
 
 #-----------COMMON VARIABLES -----------------------
 variable "tags" {
-  type    = any
-  default = {}
+  description = "IRSA Input configuration for the addon_context"
+  type        = any
+  default     = {}
 }
 
 variable "irsa_iam_role_path" {
-  type    = any
-  default = {}
+  description = "IRSA Input configuration for the addon_context"
+  type        = any
+  default     = {}
 }
 
 variable "irsa_iam_permissions_boundary" {
-  type    = any
-  default = {}
+  description = "IRSA Input configuration for the addon_context"
+  type        = any
+  default     = {}
 }
 
 variable "manage_via_gitops" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
+  description = "Set this to `true` if managing addons via GitOps. Seting `true` will not create helm-release for addon."
 }
 
 variable "data_plane_wait_arn" {
-  type    = string
-  default = ""
+  description = "This waits for the data plane to be ready"
+  type        = string
+  default     = ""
 }
 
 variable "eks_cluster_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,7 @@ variable "istio_ingress_helm_config" {
 }
 
 variable "istio_manifests" {
+  description = "Path of Ingress and Gateway yaml manifests"
   type = object({
     istio_ingress_manifest_file_path = list(any)
     istio_gateway_manifest_file_path = list(any)
@@ -206,6 +207,7 @@ variable "kiali_server_helm_config" {
 
 
 variable "kiali_manifests" {
+  description = "Path of virtual-service yaml manifests"
   type = object({
     kiali_virtualservice_file_path = string
   })
@@ -361,8 +363,9 @@ variable "data_plane_wait_arn" {
 }
 
 variable "eks_cluster_name" {
-  type    = string
-  default = ""
+  description = "Name of eks cluster"
+  type        = string
+  default     = ""
 }
 
 #----------- FLUENT-BIT ----------------------------


### PR DESCRIPTION
## What
- Updated `istio-ingress` addon to use Internet-facing and Internal ingresses.
- Added feature to use externalSecret in other namespaces.
- To do so User need to create an TrustRelationship policy where user will pass information of other namespace.
- Then in their application's service-account.yaml, user have to pass IAMRole annotation as below -
```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: 
  annotations:
    eks.amazonaws.com/role-arn: "arn:aws:iam::12345678912:role/external-secrets-CLUSTER_NAME"
```
## Why
- Previously we were only able to use external-secret in the namespace where this addon is deployed [kube-system].
- To use this external-secret in different namespace-X we had to create a ServiceAccount in namespace-X with AWSSecretManager permission.

