### PR TITLE
Feat: Updated README for Prerequisites before setting-up Cluster Autoscaler.

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '_examples/**' 
   workflow_dispatch:
 
 jobs:
@@ -90,7 +88,7 @@ jobs:
       - name: Generate TF Docs
         uses: terraform-docs/gh-actions@v1.0.0
         with:
-          working-dir: addons/aws-ebs-csi-driver,addons/aws-efs-csi-driver,addons/aws-load-balancer-controller,addons/aws-node-termination-handler,addons/calico-tigera,addons/cluster-autoscaler,addons/external-secrets,addons/fluent-bit,addons/helm,addons/ingress-nginx,addons/istio-ingress,addons/karpenter,addons/kiali-server,addons/kubeclarity,addons/metrics-server,addons/nri-bundle,addons/velero,addons/kube-state-metrics,addons/keda,addons/cert-manager,addons/filebeat,addons/reloader,addons/external-dns,addons/redis,addons/actions-runner-controller
+          working-dir: addons/aws-ebs-csi-driver,addons/aws-efs-csi-driver,addons/aws-load-balancer-controller,addons/aws-node-termination-handler,addons/calico-tigera,addons/cluster-autoscaler,addons/external-secrets,addons/fluent-bit,addons/helm,addons/ingress-nginx,addons/istio-ingress,addons/karpenter,addons/kiali-server,addons/kubeclarity,addons/metrics-server,addons/nri-bundle,addons/velero,addons/kube-state-metrics,addons/keda,addons/cert-manager,addons/filebeat,addons/reloader,addons/external-dns,addons/redis,addons/actions-runner-controller,addons/prometheus-cloudwatch-exporter
           git-push: true
           template: |-
             <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/_examples/complete/config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml
+++ b/_examples/complete/config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml
@@ -22,30 +22,80 @@ resources:
 # Configuration is rendered with `tpl` function, therefore you can use any Helm variables and/or templates here
 config: |-
   # This is the default configuration for prometheus-cloudwatch-exporter
-  region: eu-west-1
-  period_seconds: 240
+  region: us-east-1
   metrics:
-  - aws_namespace: AWS/ELB
-    aws_metric_name: HealthyHostCount
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Average]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: UnHealthyHostCount
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Average]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: RequestCount
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Sum]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: Latency
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Average]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: SurgeQueueLength
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Maximum, Sum]
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: CPUUtilization
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+    aws_tag_select:
+      resource_type_selection: ec2:instance
+      resource_id_dimension: InstanceId
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: NetworkIn
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: NetworkOut
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: NetworkPacketsIn
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: NetworkPacketsOut
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: DiskWriteBytes
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: DiskReadBytes
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: CPUCreditBalance
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: CPUCreditUsage
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Average
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: StatusCheckFailed
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Sum
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: StatusCheckFailed_Instance
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Sum
+  - aws_dimensions:
+    - InstanceId
+    aws_metric_name: StatusCheckFailed_System
+    aws_namespace: AWS/EC2
+    aws_statistics:
+    - Sum

--- a/_examples/complete/config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml
+++ b/_examples/complete/config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml
@@ -1,0 +1,51 @@
+## Node affinity for particular node in which labels key is "Infra-Services" and value is "true"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: "eks.amazonaws.com/nodegroup"
+          operator: In
+          values:
+          - "critical"
+
+## Using limits and requests
+resources:
+  limits:
+    cpu: 300m
+    memory: 250Mi
+  requests:
+    cpu: 50m
+    memory: 150Mi
+
+# Configuration is rendered with `tpl` function, therefore you can use any Helm variables and/or templates here
+config: |-
+  # This is the default configuration for prometheus-cloudwatch-exporter
+  region: eu-west-1
+  period_seconds: 240
+  metrics:
+  - aws_namespace: AWS/ELB
+    aws_metric_name: HealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: UnHealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: RequestCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Sum]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: Latency
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: SurgeQueueLength
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Maximum, Sum]

--- a/_examples/complete/config/prometheus-cloudwatch-exporter/secret.yaml
+++ b/_examples/complete/config/prometheus-cloudwatch-exporter/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws
+  namespace: monitoring     # Namespace of Prometheus Cloudwatch Exporter addon destination
+type: Opaque
+data:
+  access_key: QUtJQVdGV0VLSlBTQU9INVlIRlQK                               # Encoded AWS Access key  -  Enter Correct AWS Access Key Encoded with base64
+  secret_key: SjZLVDRTSkZIVG9leTQ1M2hadllmMWZpR2pYa0l1UkFmYkhLRHpUdAo=   # Encoded AWS Secret Access key  - Enter Correct AWS Secret Access Key Encoded with base64
+  # Refer https://www.baeldung.com/linux/cli-base64-encode-decode this URL to Encode and Decode of String in Base64

--- a/_examples/complete/main.tf
+++ b/_examples/complete/main.tf
@@ -76,10 +76,10 @@ module "eks" {
       policy_arn = aws_iam_policy.node_additional.arn
     }
     tags = {
-      "kubernetes.io/cluster/${module.eks.cluster_name}"  = "shared"
-      "k8s.io/cluster-autoscaler/enabled" = module.eks.cluster_name
+      "kubernetes.io/cluster/${module.eks.cluster_name}"     = "shared"
+      "k8s.io/cluster-autoscaler/enabled"                    = module.eks.cluster_name
       "k8s.io/cluster-autoscaler/${module.eks.cluster_name}" = module.eks.cluster_name
-      "karpenter.sh/discovery/${module.eks.cluster_name}" = module.eks.cluster_name
+      "karpenter.sh/discovery/${module.eks.cluster_name}"    = module.eks.cluster_name
     }
   }
 

--- a/_examples/complete/main.tf
+++ b/_examples/complete/main.tf
@@ -77,6 +77,8 @@ module "eks" {
     }
     tags = {
       "kubernetes.io/cluster/${module.eks.cluster_name}"  = "shared"
+      "k8s.io/cluster-autoscaler/enabled" = module.eks.cluster_name
+      "k8s.io/cluster-autoscaler/${module.eks.cluster_name}" = module.eks.cluster_name
       "karpenter.sh/discovery/${module.eks.cluster_name}" = module.eks.cluster_name
     }
   }
@@ -153,7 +155,7 @@ module "addons" {
 
   # -- Enable Addons
   metrics_server                 = true
-  cluster_autoscaler             = true
+  cluster_autoscaler             = true # Read Prerequisites in [this](https://github.com/clouddrove/terraform-aws-eks-addons/blob/master/addons/cluster-autoscaler/README.md) before creating cluster autoscaler.
   aws_load_balancer_controller   = true
   aws_node_termination_handler   = true
   aws_efs_csi_driver             = true

--- a/_examples/complete/main.tf
+++ b/_examples/complete/main.tf
@@ -152,88 +152,90 @@ module "addons" {
   eks_cluster_name = module.eks.cluster_name
 
   # -- Enable Addons
-  metrics_server               = true
-  cluster_autoscaler           = true
-  aws_load_balancer_controller = true
-  aws_node_termination_handler = true
-  aws_efs_csi_driver           = true
-  aws_ebs_csi_driver           = true
-  kube_state_metrics           = true
-  karpenter                    = false # -- Set to `false` or comment line to Uninstall Karpenter if installed using terraform.
-  calico_tigera                = true
-  new_relic                    = true
-  kubeclarity                  = true
-  ingress_nginx                = true
-  fluent_bit                   = true
-  velero                       = true
-  keda                         = true
-  certification_manager        = true
-  filebeat                     = true
-  reloader                     = true
-  external_dns                 = true
-  redis                        = true
-  actions_runner_controller    = true
-
-
+  metrics_server                 = false
+  cluster_autoscaler             = false
+  aws_load_balancer_controller   = false
+  aws_node_termination_handler   = true
+  aws_efs_csi_driver             = false
+  aws_ebs_csi_driver             = false
+  kube_state_metrics             = false
+  karpenter                      = false # -- Set to `false` or comment line to Uninstall Karpenter if installed using terraform.
+  calico_tigera                  = false
+  new_relic                      = false
+  kubeclarity                    = false
+  ingress_nginx                  = false
+  fluent_bit                     = false
+  velero                         = false
+  keda                           = false
+  certification_manager          = false
+  filebeat                       = false
+  reloader                       = false
+  external_dns                   = false
+  redis                          = false
+  actions_runner_controller      = false
+  prometheus_cloudwatch_exporter = true
 
   # -- Addons with mandatory variable
-  istio_ingress    = true
+  istio_ingress    = false
   istio_manifests  = var.istio_manifests
-  kiali_server     = true
+  kiali_server     = false
   kiali_manifests  = var.kiali_manifests
-  external_secrets = true
+  external_secrets = false
 
   # -- Path of override-values.yaml file
-  metrics_server_helm_config               = { values = [file("./config/override-metrics-server.yaml")] }
-  cluster_autoscaler_helm_config           = { values = [file("./config/override-cluster-autoscaler.yaml")] }
-  karpenter_helm_config                    = { values = [file("./config/override-karpenter.yaml")] }
-  aws_load_balancer_controller_helm_config = { values = [file("./config/override-aws-load-balancer-controller.yaml")] }
-  aws_node_termination_handler_helm_config = { values = [file("./config/override-aws-node-termination-handler.yaml")] }
-  aws_efs_csi_driver_helm_config           = { values = [file("./config/override-aws-efs-csi-driver.yaml")] }
-  aws_ebs_csi_driver_helm_config           = { values = [file("./config/override-aws-ebs-csi-driver.yaml")] }
-  calico_tigera_helm_config                = { values = [file("./config/calico-tigera-values.yaml")] }
-  istio_ingress_helm_config                = { values = [file("./config/istio/override-values.yaml")] }
-  kiali_server_helm_config                 = { values = [file("./config/kiali/override-values.yaml")] }
-  external_secrets_helm_config             = { values = [file("./config/external-secret/override-values.yaml")] }
-  ingress_nginx_helm_config                = { values = [file("./config/override-ingress-nginx.yaml")] }
-  kubeclarity_helm_config                  = { values = [file("./config/override-kubeclarity.yaml")] }
-  fluent_bit_helm_config                   = { values = [file("./config/override-fluent-bit.yaml")] }
-  velero_helm_config                       = { values = [file("./config/override-velero.yaml")] }
-  new_relic_helm_config                    = { values = [file("./config/override-new-relic.yaml")] }
-  kube_state_metrics_helm_config           = { values = [file("./config/override-kube-state-matrics.yaml")] }
-  keda_helm_config                         = { values = [file("./config/keda/override-keda.yaml")] }
-  certification_manager_helm_config        = { values = [file("./config/override-certification-manager.yaml")] }
-  filebeat_helm_config                     = { values = [file("./config/override-filebeat.yaml")] }
-  reloader_helm_config                     = { values = [file("./config/reloader/override-reloader.yaml")] }
-  external_dns_helm_config                 = { values = [file("./config/override-external-dns.yaml")] }
-  redis_helm_config                        = { values = [file("./config/override-redis.yaml")] }
-  actions_runner_controller_helm_config    = { values = [file("./config/override-actions-runner-controller.yaml")] }
+  metrics_server_helm_config                     = { values = [file("./config/override-metrics-server.yaml")] }
+  cluster_autoscaler_helm_config                 = { values = [file("./config/override-cluster-autoscaler.yaml")] }
+  karpenter_helm_config                          = { values = [file("./config/override-karpenter.yaml")] }
+  aws_load_balancer_controller_helm_config       = { values = [file("./config/override-aws-load-balancer-controller.yaml")] }
+  aws_node_termination_handler_helm_config       = { values = [file("./config/override-aws-node-termination-handler.yaml")] }
+  aws_efs_csi_driver_helm_config                 = { values = [file("./config/override-aws-efs-csi-driver.yaml")] }
+  aws_ebs_csi_driver_helm_config                 = { values = [file("./config/override-aws-ebs-csi-driver.yaml")] }
+  calico_tigera_helm_config                      = { values = [file("./config/calico-tigera-values.yaml")] }
+  istio_ingress_helm_config                      = { values = [file("./config/istio/override-values.yaml")] }
+  kiali_server_helm_config                       = { values = [file("./config/kiali/override-values.yaml")] }
+  external_secrets_helm_config                   = { values = [file("./config/external-secret/override-values.yaml")] }
+  ingress_nginx_helm_config                      = { values = [file("./config/override-ingress-nginx.yaml")] }
+  kubeclarity_helm_config                        = { values = [file("./config/override-kubeclarity.yaml")] }
+  fluent_bit_helm_config                         = { values = [file("./config/override-fluent-bit.yaml")] }
+  velero_helm_config                             = { values = [file("./config/override-velero.yaml")] }
+  new_relic_helm_config                          = { values = [file("./config/override-new-relic.yaml")] }
+  kube_state_metrics_helm_config                 = { values = [file("./config/override-kube-state-matrics.yaml")] }
+  keda_helm_config                               = { values = [file("./config/keda/override-keda.yaml")] }
+  certification_manager_helm_config              = { values = [file("./config/override-certification-manager.yaml")] }
+  filebeat_helm_config                           = { values = [file("./config/override-filebeat.yaml")] }
+  reloader_helm_config                           = { values = [file("./config/reloader/override-reloader.yaml")] }
+  external_dns_helm_config                       = { values = [file("./config/override-external-dns.yaml")] }
+  redis_helm_config                              = { values = [file("./config/override-redis.yaml")] }
+  actions_runner_controller_helm_config          = { values = [file("./config/override-actions-runner-controller.yaml")] }
+  prometheus_cloudwatch_exporter_helm_config     = { values = [file("./config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml")] }
+  prometheus_cloudwatch_exporter_secret_manifest = ["./config/prometheus-cloudwatch-exporter/secret.yaml"]
 
   # -- Override Helm Release attributes
-  metrics_server_extra_configs               = var.metrics_server_extra_configs
-  cluster_autoscaler_extra_configs           = var.cluster_autoscaler_extra_configs
-  karpenter_extra_configs                    = var.karpenter_extra_configs
-  aws_load_balancer_controller_extra_configs = var.aws_load_balancer_controller_extra_configs
-  aws_node_termination_handler_extra_configs = var.aws_node_termination_handler_extra_configs
-  aws_efs_csi_driver_extra_configs           = var.aws_efs_csi_driver_extra_configs
-  aws_ebs_csi_driver_extra_configs           = var.aws_ebs_csi_driver_extra_configs
-  calico_tigera_extra_configs                = var.calico_tigera_extra_configs
-  istio_ingress_extra_configs                = var.istio_ingress_extra_configs
-  kiali_server_extra_configs                 = var.kiali_server_extra_configs
-  ingress_nginx_extra_configs                = var.ingress_nginx_extra_configs
-  kubeclarity_extra_configs                  = var.kubeclarity_extra_configs
-  fluent_bit_extra_configs                   = var.fluent_bit_extra_configs
-  velero_extra_configs                       = var.velero_extra_configs
-  new_relic_extra_configs                    = var.new_relic_extra_configs
-  kube_state_metrics_extra_configs           = var.kube_state_metrics_extra_configs
-  keda_extra_configs                         = var.keda_extra_configs
-  certification_manager_extra_configs        = var.certification_manager_extra_configs
-  external_secrets_extra_configs             = var.external_secrets_extra_configs
-  filebeat_extra_configs                     = var.filebeat_extra_configs
-  reloader_extra_configs                     = var.reloader_extra_configs
-  external_dns_extra_configs                 = var.external_dns_extra_configs
-  redis_extra_configs                        = var.redis_extra_configs
-  actions_runner_controller_extra_configs    = var.actions_runner_controller_extra_configs
+  metrics_server_extra_configs                 = var.metrics_server_extra_configs
+  cluster_autoscaler_extra_configs             = var.cluster_autoscaler_extra_configs
+  karpenter_extra_configs                      = var.karpenter_extra_configs
+  aws_load_balancer_controller_extra_configs   = var.aws_load_balancer_controller_extra_configs
+  aws_node_termination_handler_extra_configs   = var.aws_node_termination_handler_extra_configs
+  aws_efs_csi_driver_extra_configs             = var.aws_efs_csi_driver_extra_configs
+  aws_ebs_csi_driver_extra_configs             = var.aws_ebs_csi_driver_extra_configs
+  calico_tigera_extra_configs                  = var.calico_tigera_extra_configs
+  istio_ingress_extra_configs                  = var.istio_ingress_extra_configs
+  kiali_server_extra_configs                   = var.kiali_server_extra_configs
+  ingress_nginx_extra_configs                  = var.ingress_nginx_extra_configs
+  kubeclarity_extra_configs                    = var.kubeclarity_extra_configs
+  fluent_bit_extra_configs                     = var.fluent_bit_extra_configs
+  velero_extra_configs                         = var.velero_extra_configs
+  new_relic_extra_configs                      = var.new_relic_extra_configs
+  kube_state_metrics_extra_configs             = var.kube_state_metrics_extra_configs
+  keda_extra_configs                           = var.keda_extra_configs
+  certification_manager_extra_configs          = var.certification_manager_extra_configs
+  external_secrets_extra_configs               = var.external_secrets_extra_configs
+  filebeat_extra_configs                       = var.filebeat_extra_configs
+  reloader_extra_configs                       = var.reloader_extra_configs
+  external_dns_extra_configs                   = var.external_dns_extra_configs
+  redis_extra_configs                          = var.redis_extra_configs
+  actions_runner_controller_extra_configs      = var.actions_runner_controller_extra_configs
+  prometheus_cloudwatch_exporter_extra_configs = var.prometheus_cloudwatch_exporter_extra_configs
 
   # -- Custom IAM Policy Json for Addon's ServiceAccount
   cluster_autoscaler_iampolicy_json_content = file("./custom-iam-policies/cluster-autoscaler.json")
@@ -246,7 +248,7 @@ module "addons-internal" {
   depends_on       = [module.eks]
   eks_cluster_name = module.eks.cluster_name
 
-  istio_ingress               = true
+  istio_ingress               = false
   istio_manifests             = var.istio_manifests_internal
   istio_ingress_extra_configs = var.istio_ingress_extra_configs_internal
 }

--- a/_examples/complete/main.tf
+++ b/_examples/complete/main.tf
@@ -152,35 +152,35 @@ module "addons" {
   eks_cluster_name = module.eks.cluster_name
 
   # -- Enable Addons
-  metrics_server                 = false
-  cluster_autoscaler             = false
-  aws_load_balancer_controller   = false
+  metrics_server                 = true
+  cluster_autoscaler             = true
+  aws_load_balancer_controller   = true
   aws_node_termination_handler   = true
-  aws_efs_csi_driver             = false
-  aws_ebs_csi_driver             = false
-  kube_state_metrics             = false
+  aws_efs_csi_driver             = true
+  aws_ebs_csi_driver             = true
+  kube_state_metrics             = true
   karpenter                      = false # -- Set to `false` or comment line to Uninstall Karpenter if installed using terraform.
-  calico_tigera                  = false
-  new_relic                      = false
-  kubeclarity                    = false
-  ingress_nginx                  = false
-  fluent_bit                     = false
-  velero                         = false
-  keda                           = false
-  certification_manager          = false
-  filebeat                       = false
-  reloader                       = false
-  external_dns                   = false
-  redis                          = false
-  actions_runner_controller      = false
+  calico_tigera                  = true
+  new_relic                      = true
+  kubeclarity                    = true
+  ingress_nginx                  = true
+  fluent_bit                     = true
+  velero                         = true
+  keda                           = true
+  certification_manager          = true
+  filebeat                       = true
+  reloader                       = true
+  external_dns                   = true
+  redis                          = true
+  actions_runner_controller      = true
   prometheus_cloudwatch_exporter = true
 
   # -- Addons with mandatory variable
-  istio_ingress    = false
+  istio_ingress    = true
   istio_manifests  = var.istio_manifests
-  kiali_server     = false
+  kiali_server     = true
   kiali_manifests  = var.kiali_manifests
-  external_secrets = false
+  external_secrets = true
 
   # -- Path of override-values.yaml file
   metrics_server_helm_config                     = { values = [file("./config/override-metrics-server.yaml")] }

--- a/_examples/complete/variables.tf
+++ b/_examples/complete/variables.tf
@@ -208,3 +208,9 @@ variable "actions_runner_controller_extra_configs" {
   type    = any
   default = {}
 }
+
+# ---------------------- PROMETHEUS-CLOUDWATCH-EXPORTER ------------------------------------------------
+variable "prometheus_cloudwatch_exporter_extra_configs" {
+  type    = any
+  default = {}
+}

--- a/_examples/complete/variables.tf
+++ b/_examples/complete/variables.tf
@@ -212,5 +212,7 @@ variable "actions_runner_controller_extra_configs" {
 # ---------------------- PROMETHEUS-CLOUDWATCH-EXPORTER ------------------------------------------------
 variable "prometheus_cloudwatch_exporter_extra_configs" {
   type    = any
-  default = {}
+  default     = {
+    role_name = ""
+  }
 }

--- a/_examples/complete/variables.tf
+++ b/_examples/complete/variables.tf
@@ -211,8 +211,8 @@ variable "actions_runner_controller_extra_configs" {
 
 # ---------------------- PROMETHEUS-CLOUDWATCH-EXPORTER ------------------------------------------------
 variable "prometheus_cloudwatch_exporter_extra_configs" {
-  type    = any
-  default     = {
+  type = any
+  default = {
     role_name = ""
   }
 }

--- a/_examples/external-eks/config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml
+++ b/_examples/external-eks/config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml
@@ -1,0 +1,51 @@
+## Node affinity for particular node in which labels key is "Infra-Services" and value is "true"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: "eks.amazonaws.com/nodegroup"
+          operator: In
+          values:
+          - "critical"
+
+## Using limits and requests
+resources:
+  limits:
+    cpu: 300m
+    memory: 250Mi
+  requests:
+    cpu: 50m
+    memory: 150Mi
+
+# Configuration is rendered with `tpl` function, therefore you can use any Helm variables and/or templates here
+config: |-
+  # This is the default configuration for prometheus-cloudwatch-exporter
+  region: eu-west-1
+  period_seconds: 240
+  metrics:
+  - aws_namespace: AWS/ELB
+    aws_metric_name: HealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: UnHealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: RequestCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Sum]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: Latency
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: SurgeQueueLength
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Maximum, Sum]

--- a/_examples/external-eks/config/prometheus-cloudwatch-exporter/secret.yaml
+++ b/_examples/external-eks/config/prometheus-cloudwatch-exporter/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws
+  namespace: monitoring     # Namespace of Prometheus Cloudwatch Exporter addon destination
+type: Opaque
+data:
+  access_key: QUtJQVdGV0VLSlBTQU9INVlIRlQK                               # Encoded AWS Access key  -  Enter Correct AWS Access Key Encoded with base64
+  secret_key: SjZLVDRTSkZIVG9leTQ1M2hadllmMWZpR2pYa0l1UkFmYkhLRHpUdAo=   # Encoded AWS Secret Access key  - Enter Correct AWS Secret Access Key Encoded with base64
+  # Refer https://www.baeldung.com/linux/cli-base64-encode-decode this URL to Encode and Decode of String in Base64

--- a/_examples/external-eks/main.tf
+++ b/_examples/external-eks/main.tf
@@ -13,26 +13,26 @@ module "addons" {
   eks_cluster_name = local.name
 
   # -- Enable Addons
-  metrics_server               = true
-  cluster_autoscaler           = true
-  aws_load_balancer_controller = true
-  aws_node_termination_handler = true
-  aws_efs_csi_driver           = true
-  aws_ebs_csi_driver           = true
-  kube_state_metrics           = true
-  karpenter                    = false # -- Set to `false` or comment line to Uninstall Karpenter if installed using terraform.
-  calico_tigera                = true
-  new_relic                    = true
-  kubeclarity                  = true
-  ingress_nginx                = true
-  fluent_bit                   = true
-  velero                       = true
-  keda                         = true
-  certification_manager        = true
-  filebeat                     = true
-  reloader                     = true
-  redis                        = true
-
+  metrics_server                 = true
+  cluster_autoscaler             = true
+  aws_load_balancer_controller   = true
+  aws_node_termination_handler   = true
+  aws_efs_csi_driver             = true
+  aws_ebs_csi_driver             = true
+  kube_state_metrics             = true
+  karpenter                      = false # -- Set to `false` or comment line to Uninstall Karpenter if installed using terraform.
+  calico_tigera                  = true
+  new_relic                      = true
+  kubeclarity                    = true
+  ingress_nginx                  = true
+  fluent_bit                     = true
+  velero                         = true
+  keda                           = true
+  certification_manager          = true
+  filebeat                       = true
+  reloader                       = true
+  redis                          = true
+  prometheus_cloudwatch_exporter = true
 
   # -- Addons with mandatory variable
   istio_ingress    = true
@@ -42,53 +42,55 @@ module "addons" {
   external_secrets = true
 
   # -- Path of override-values.yaml file
-  metrics_server_helm_config               = { values = [file("./config/override-metrics-server.yaml")] }
-  cluster_autoscaler_helm_config           = { values = [file("./config/override-cluster-autoscaler.yaml")] }
-  karpenter_helm_config                    = { values = [file("./config/override-karpenter.yaml")] }
-  aws_load_balancer_controller_helm_config = { values = [file("./config/override-aws-load-balancer-controller.yaml")] }
-  aws_node_termination_handler_helm_config = { values = [file("./config/override-aws-node-termination-handler.yaml")] }
-  aws_efs_csi_driver_helm_config           = { values = [file("./config/override-aws-efs-csi-driver.yaml")] }
-  aws_ebs_csi_driver_helm_config           = { values = [file("./config/override-aws-ebs-csi-driver.yaml")] }
-  calico_tigera_helm_config                = { values = [file("./config/calico-tigera-values.yaml")] }
-  istio_ingress_helm_config                = { values = [file("./config/istio/override-values.yaml")] }
-  kiali_server_helm_config                 = { values = [file("./config/kiali/override-values.yaml")] }
-  external_secrets_helm_config             = { values = [file("./config/external-secret/override-values.yaml")] }
-  ingress_nginx_helm_config                = { values = [file("./config/override-ingress-nginx.yaml")] }
-  kubeclarity_helm_config                  = { values = [file("./config/override-kubeclarity.yaml")] }
-  fluent_bit_helm_config                   = { values = [file("./config/override-fluent-bit.yaml")] }
-  velero_helm_config                       = { values = [file("./config/override-velero.yaml")] }
-  new_relic_helm_config                    = { values = [file("./config/override-new-relic.yaml")] }
-  kube_state_metrics_helm_config           = { values = [file("./config/override-kube-state-matrics.yaml")] }
-  keda_helm_config                         = { values = [file("./config/keda/override-keda.yaml")] }
-  certification_manager_helm_config        = { values = [file("./config/override-certification-manager.yaml")] }
-  filebeat_helm_config                     = { values = [file("./config/override-filebeat.yaml")] }
-  reloader_helm_config                     = { values = [file("./config/reloader/override-reloader.yaml")] }
-  redis_helm_config                        = { values = [file("./config/override-redis.yaml")] }
+  metrics_server_helm_config                     = { values = [file("./config/override-metrics-server.yaml")] }
+  cluster_autoscaler_helm_config                 = { values = [file("./config/override-cluster-autoscaler.yaml")] }
+  karpenter_helm_config                          = { values = [file("./config/override-karpenter.yaml")] }
+  aws_load_balancer_controller_helm_config       = { values = [file("./config/override-aws-load-balancer-controller.yaml")] }
+  aws_node_termination_handler_helm_config       = { values = [file("./config/override-aws-node-termination-handler.yaml")] }
+  aws_efs_csi_driver_helm_config                 = { values = [file("./config/override-aws-efs-csi-driver.yaml")] }
+  aws_ebs_csi_driver_helm_config                 = { values = [file("./config/override-aws-ebs-csi-driver.yaml")] }
+  calico_tigera_helm_config                      = { values = [file("./config/calico-tigera-values.yaml")] }
+  istio_ingress_helm_config                      = { values = [file("./config/istio/override-values.yaml")] }
+  kiali_server_helm_config                       = { values = [file("./config/kiali/override-values.yaml")] }
+  external_secrets_helm_config                   = { values = [file("./config/external-secret/override-values.yaml")] }
+  ingress_nginx_helm_config                      = { values = [file("./config/override-ingress-nginx.yaml")] }
+  kubeclarity_helm_config                        = { values = [file("./config/override-kubeclarity.yaml")] }
+  fluent_bit_helm_config                         = { values = [file("./config/override-fluent-bit.yaml")] }
+  velero_helm_config                             = { values = [file("./config/override-velero.yaml")] }
+  new_relic_helm_config                          = { values = [file("./config/override-new-relic.yaml")] }
+  kube_state_metrics_helm_config                 = { values = [file("./config/override-kube-state-matrics.yaml")] }
+  keda_helm_config                               = { values = [file("./config/keda/override-keda.yaml")] }
+  certification_manager_helm_config              = { values = [file("./config/override-certification-manager.yaml")] }
+  filebeat_helm_config                           = { values = [file("./config/override-filebeat.yaml")] }
+  reloader_helm_config                           = { values = [file("./config/reloader/override-reloader.yaml")] }
+  redis_helm_config                              = { values = [file("./config/override-redis.yaml")] }
+  prometheus_cloudwatch_exporter_helm_config     = { values = [file("./config/prometheus-cloudwatch-exporter/override-prometheus-cloudwatch-exporter-controller.yaml")] }
+  prometheus_cloudwatch_exporter_secret_manifest = ["./config/prometheus-cloudwatch-exporter/secret.yaml"]
 
   # -- Override Helm Release attributes
-  metrics_server_extra_configs               = var.metrics_server_extra_configs
-  cluster_autoscaler_extra_configs           = var.cluster_autoscaler_extra_configs
-  karpenter_extra_configs                    = var.karpenter_extra_configs
-  aws_load_balancer_controller_extra_configs = var.aws_load_balancer_controller_extra_configs
-  aws_node_termination_handler_extra_configs = var.aws_node_termination_handler_extra_configs
-  aws_efs_csi_driver_extra_configs           = var.aws_efs_csi_driver_extra_configs
-  aws_ebs_csi_driver_extra_configs           = var.aws_ebs_csi_driver_extra_configs
-  calico_tigera_extra_configs                = var.calico_tigera_extra_configs
-  istio_ingress_extra_configs                = var.istio_ingress_extra_configs
-  kiali_server_extra_configs                 = var.kiali_server_extra_configs
-  ingress_nginx_extra_configs                = var.ingress_nginx_extra_configs
-  kubeclarity_extra_configs                  = var.kubeclarity_extra_configs
-  fluent_bit_extra_configs                   = var.fluent_bit_extra_configs
-  velero_extra_configs                       = var.velero_extra_configs
-  new_relic_extra_configs                    = var.new_relic_extra_configs
-  kube_state_metrics_extra_configs           = var.kube_state_metrics_extra_configs
-  keda_extra_configs                         = var.keda_extra_configs
-  certification_manager_extra_configs        = var.certification_manager_extra_configs
-  external_secrets_extra_configs             = var.external_secrets_extra_configs
-  filebeat_extra_configs                     = var.filebeat_extra_configs
-  reloader_extra_configs                     = var.reloader_extra_configs
-  redis_extra_configs                        = var.redis_extra_configs
-
+  metrics_server_extra_configs                 = var.metrics_server_extra_configs
+  cluster_autoscaler_extra_configs             = var.cluster_autoscaler_extra_configs
+  karpenter_extra_configs                      = var.karpenter_extra_configs
+  aws_load_balancer_controller_extra_configs   = var.aws_load_balancer_controller_extra_configs
+  aws_node_termination_handler_extra_configs   = var.aws_node_termination_handler_extra_configs
+  aws_efs_csi_driver_extra_configs             = var.aws_efs_csi_driver_extra_configs
+  aws_ebs_csi_driver_extra_configs             = var.aws_ebs_csi_driver_extra_configs
+  calico_tigera_extra_configs                  = var.calico_tigera_extra_configs
+  istio_ingress_extra_configs                  = var.istio_ingress_extra_configs
+  kiali_server_extra_configs                   = var.kiali_server_extra_configs
+  ingress_nginx_extra_configs                  = var.ingress_nginx_extra_configs
+  kubeclarity_extra_configs                    = var.kubeclarity_extra_configs
+  fluent_bit_extra_configs                     = var.fluent_bit_extra_configs
+  velero_extra_configs                         = var.velero_extra_configs
+  new_relic_extra_configs                      = var.new_relic_extra_configs
+  kube_state_metrics_extra_configs             = var.kube_state_metrics_extra_configs
+  keda_extra_configs                           = var.keda_extra_configs
+  certification_manager_extra_configs          = var.certification_manager_extra_configs
+  external_secrets_extra_configs               = var.external_secrets_extra_configs
+  filebeat_extra_configs                       = var.filebeat_extra_configs
+  reloader_extra_configs                       = var.reloader_extra_configs
+  redis_extra_configs                          = var.redis_extra_configs
+  prometheus_cloudwatch_exporter_extra_configs = var.prometheus_cloudwatch_exporter_extra_configs
 
   # -- Custom IAM Policy Json for Addon's ServiceAccount
   external_secrets_iampolicy_json_content = file("./custom-iam-policies/external-secrets.json")

--- a/_examples/external-eks/variables.tf
+++ b/_examples/external-eks/variables.tf
@@ -175,8 +175,8 @@ variable "redis_extra_configs" {
 
 # ---------------------- PROMETHEUS-CLOUDWATCH-EXPORTER ------------------------------------------------
 variable "prometheus_cloudwatch_exporter_extra_configs" {
-  type    = any
-  default     = {
+  type = any
+  default = {
     role_name = ""
   }
 }

--- a/_examples/external-eks/variables.tf
+++ b/_examples/external-eks/variables.tf
@@ -172,3 +172,11 @@ variable "redis_extra_configs" {
     timeout = 300
   }
 }
+
+# ---------------------- PROMETHEUS-CLOUDWATCH-EXPORTER ------------------------------------------------
+variable "prometheus_cloudwatch_exporter_extra_configs" {
+  type    = any
+  default     = {
+    role_name = ""
+  }
+}

--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -4,6 +4,10 @@ Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernet
 - there are pods that failed to run in the cluster due to insufficient resources.
 - there are nodes in the cluster that have been underutilized for an extended period of time and their pods can be placed on other existing nodes.
 
+## Prerequisites
+Auto-discovery finds ASGs tags as below and automatically manages them based on the min and max size specified in the ASG.
+- Tag the ASGs with keys to match .Values.autoDiscovery.tags, by default: `k8s.io/cluster-autoscaler/enabled` and `k8s.io/cluster-autoscaler/<YOUR CLUSTER NAME>`
+
 ## Installation
 Below terraform script shows how to use Cluster Autoscaler Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
 ```hcl

--- a/addons/fluent-bit/README.md
+++ b/addons/fluent-bit/README.md
@@ -4,7 +4,7 @@ Fluent Bit is a lightweight log processor and forwarder that you use to collect 
 
 ## Installation
 Below terraform script shows how to use FluentBit Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
-```bash
+```hcl
 module "addons" {
   source  = "clouddrove/eks-addons/aws"
   version = "0.0.4"

--- a/addons/ingress-nginx/README.md
+++ b/addons/ingress-nginx/README.md
@@ -9,7 +9,7 @@ Below terraform script shows how to use Ingress Nginx Terraform Addon, A complet
 user can change this behaviour according to their need. They just have to change values in `/_example/complete/config/override-ingress-nginx.yaml` file. User can also add annotations according to their need or they can add their own config file by the same name.
 
 - if user wants to change `namespace`, `chart version`, `timeout`, `atomic`  and other helm artributes, A complete list of artributes is also given here [here](https://github.com/clouddrove/terraform-aws-eks-addons/blob/master/addons/helm/main.tf#L3-L32). then they can change this in `/_example/complate/variable.tf` at 
-```bash
+```hcl
 #--------------INGRESS NGINX------------
 variable "ingress_nginx_extra_configs" {
   type = any
@@ -17,7 +17,7 @@ variable "ingress_nginx_extra_configs" {
 }
 ``` 
 
-```bash
+```hcl
 module "addons" {
   source = "../../"
   depends_on       = [null_resource.kubectl]

--- a/addons/istio-ingress/README.md
+++ b/addons/istio-ingress/README.md
@@ -4,7 +4,7 @@ Istio is a service mesh—a modernized service networking layer that provides a 
 
 ## Installation
 Below terraform script shows how to use Istio-Ingress Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
-```bash
+```hcl
 module "addons" {
   source  = "clouddrove/eks-addons/aws"
   version = "0.0.1"

--- a/addons/karpenter/README.md
+++ b/addons/karpenter/README.md
@@ -4,7 +4,7 @@ Karpenter simplifies Kubernetes infrastructure with the right nodes at the right
 
 ## Installation
 Below terraform script shows how to use Karpenter Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
-```bash
+```hcl
 module "addons" {
   source  = "clouddrove/eks-addons/aws"
   version = "0.0.1"

--- a/addons/keda/README.md
+++ b/addons/keda/README.md
@@ -4,7 +4,7 @@ KEDA allows for fine grained autoscaling (including to/from zero) for event driv
 
 ## Installation
 Below terraform script shows how to use Keda Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
-```bash
+```hcl
 module "addons" {
   source  = "clouddrove/eks-addons/aws"
   version = "0.0.9"

--- a/addons/kiali-server/README.md
+++ b/addons/kiali-server/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 Below terraform script shows how to use Kiali-Server Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
-```bash
+```hcl
 module "addons" {
   source  = "clouddrove/eks-addons/aws"
   version = "0.0.1"

--- a/addons/prometheus-cloudwatch-exporter/README.md
+++ b/addons/prometheus-cloudwatch-exporter/README.md
@@ -17,7 +17,7 @@ module "addons" {
 ```
 
 ## Configuration
-[This] documentation can help you to configure CloudWatch exporter to get the metrics from AWS.
+This documentation can help you to configure CloudWatch exporter to get the metrics from AWS.
 Configuration examples for different namespaces can be found in [this](https://github.com/prometheus/cloudwatch_exporter/blob/master/examples) examples. 
 A configuration builder can be found [here](https://github.com/djloude/cloudwatch_exporter_metrics_config_builder).
 Configure the exporter for namespaces accordingly and use it in the `./config/override-prometheus-cloudwatch-exporter-controller.yaml` override file like this.

--- a/addons/prometheus-cloudwatch-exporter/README.md
+++ b/addons/prometheus-cloudwatch-exporter/README.md
@@ -1,0 +1,98 @@
+# Prometheus Cloudwatch Exporter Helm Chart
+
+The CloudWatch Exporter for Prometheus is a tool that allows you to export Amazon CloudWatch metrics in the Prometheus format. Amazon CloudWatch is a monitoring and observability service provided by AWS that provides metrics, logs, and traces from AWS resources and applications 
+
+## Installation
+Below terraform script describes how to use Prometheus Cloudwatch Exporter Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
+```hcl
+module "addons" {
+  source  = "clouddrove/eks-addons/aws"
+  version = "0.0.9"
+  
+  depends_on       = [module.eks.cluster_id]
+  eks_cluster_name = module.eks.cluster_name
+
+  prometheus_cloudwatch_exporter = true
+}
+```
+
+## Configuration
+[This] documentation can help you to configure CloudWatch exporter to get the metrics from AWS.
+Configuration examples for different namespaces can be found in [this](https://github.com/prometheus/cloudwatch_exporter/blob/master/examples) examples. 
+A configuration builder can be found [here](https://github.com/djloude/cloudwatch_exporter_metrics_config_builder).
+Configure the exporter for namespaces accordingly and use it in the `./config/override-prometheus-cloudwatch-exporter-controller.yaml` override file like this.
+
+```yaml
+## Node affinity for particular node in which labels key is "Infra-Services" and value is "true"
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: "eks.amazonaws.com/nodegroup"
+          operator: In
+          values:
+          - "critical"
+## Using limits and requests
+resources:
+  limits:
+    cpu: 300m
+    memory: 250Mi
+  requests:
+    cpu: 50m
+    memory: 150Mi
+# This config is for AWS Load balancer
+config: |-
+  # This is the default configuration for prometheus-cloudwatch-exporter
+  region: eu-west-1
+  period_seconds: 240
+  metrics:
+  - aws_namespace: AWS/ELB
+    aws_metric_name: HealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: UnHealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: RequestCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Sum]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: Latency
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: SurgeQueueLength
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Maximum, Sum]
+
+```
+
+## Authentication
+- There are two methods to Authenticate with AWS
+
+### Using Secrets
+- Update Access key and Secret Access keys from the config files provided in the examples.
+
+### Using Role (Default)
+- Don't pass secret to use Role based authentication.
+- A Role and Policy will be created for authentication with AWS.
+- Pass RoleName if you have existing role for the authentication:
+```hcl
+prometheus_cloudwatch_exporter_extra_configs = {
+  role_name = "prometheus_cloudwatch_exporter_role"
+}
+```
+- To override the default policy create `json` format file and pass it like this:
+```hcl
+prometheus_cloudwatch_exporter_iampolicy_json_content   = file("./custom-iam-policies/prometheus-cloudwatch-exporter.json")
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/addons/prometheus-cloudwatch-exporter/config/prometheus-cloudwatch-exporter.yaml
+++ b/addons/prometheus-cloudwatch-exporter/config/prometheus-cloudwatch-exporter.yaml
@@ -1,0 +1,245 @@
+# Default values for prometheus-cloudwatch-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: prom/cloudwatch-exporter
+  # if not set appVersion field from Chart.yaml is used
+  tag:
+  pullPolicy: IfNotPresent
+  pullSecrets:
+  # - name: "image-pull-secret"
+
+# Example proxy configuration:
+# command:
+#   - 'java'
+#   - '-Dhttp.proxyHost=proxy.example.com'
+#   - '-Dhttp.proxyPort=3128'
+#   - '-Dhttps.proxyHost=proxy.example.com'
+#   - '-Dhttps.proxyPort=3128'
+#   - '-jar'
+#   - '/cloudwatch_exporter.jar'
+#   - '9106'
+#   - '/config/config.yml'
+
+command: []
+
+containerPort: 9106
+
+service:
+  type: ClusterIP
+  port: 9106
+  portName: http
+  annotations: {}
+  labels: {}
+
+pod:
+  labels: {}
+  annotations: {}
+
+# Labels and annotations to attach to the deployment resource
+deployment:
+  labels: {}
+  annotations: {}
+
+# Extra environment variables
+extraEnv:
+  # - name: foo
+  #   value: baa
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #    memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+aws:
+  role:
+  # Enables usage of regional STS endpoints rather than global which is default
+  stsRegional:
+    enabled: false
+
+  # The name of a pre-created secret in which AWS credentials are stored. When
+  # set, aws_access_key_id is assumed to be in a field called access_key,
+  # aws_secret_access_key is assumed to be in a field called secret_key, and the
+  # session token, if it exists, is assumed to be in a field called
+  # security_token
+  secret:
+    name:
+    includesSessionToken: false
+
+  # Note: Do not specify the aws_access_key_id and aws_secret_access_key if you specified role or secret.name before
+  aws_access_key_id:
+  aws_secret_access_key:
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # annotations:
+  # Will add the provided map to the annotations for the created serviceAccount
+  # e.g.
+  # annotations:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/prom-cloudwatch-exporter-oidc
+  #   eks.amazonaws.com/sts-regional-endpoints: "true"
+  # Specifies whether to automount API credentials for the ServiceAccount.
+  automountServiceAccountToken: true
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+# Configuration is rendered with `tpl` function, therefore you can use any Helm variables and/or templates here
+config: |-
+  # This is the default configuration for prometheus-cloudwatch-exporter
+  region: eu-west-1
+  period_seconds: 240
+  metrics:
+  - aws_namespace: AWS/ELB
+    aws_metric_name: HealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: UnHealthyHostCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: RequestCount
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Sum]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: Latency
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/ELB
+    aws_metric_name: SurgeQueueLength
+    aws_dimensions: [AvailabilityZone, LoadBalancerName]
+    aws_statistics: [Maximum, Sum]
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Configurable health checks against the /healthy and /ready endpoints
+livenessProbe:
+  path: /-/healthy
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  path: /-/ready
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to cloudwatch-exporter telemtery-path
+  # telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set relabelings for the ServiceMonitor, use to apply to samples before scraping
+  # relabelings: []
+  # Set metricRelabelings for the ServiceMonitor, use to apply to samples for ingestion
+  # metricRelabelings: []
+  #
+  # Example - note the Kubernetes convention of camelCase instead of Prometheus' snake_case
+  # metricRelabelings:
+  #   - sourceLabels: [dbinstance_identifier]
+  #     action: replace
+  #     replacement: mydbname
+  #     targetLabel: dbname
+
+prometheusRule:
+  # Specifies whether a PrometheusRule should be created
+  enabled: false
+  # Set the namespace the PrometheusRule should be deployed
+  # namespace: monitoring
+  # Set labels for the PrometheusRule, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Example - note the Kubernetes convention of camelCase instead of Prometheus'
+  # rules:
+  #    - alert: ELB-Low-BurstBalance
+  #      annotations:
+  #        message: The ELB BurstBalance during the last 10 minutes is lower than 80%.
+  #      expr: aws_ebs_burst_balance_average < 80
+  #      for: 10m
+  #      labels:
+  #        severity: warning
+  #    - alert: ELB-Low-BurstBalance
+  #      annotations:
+  #        message: The ELB BurstBalance during the last 10 minutes is lower than 50%.
+  #      expr: aws_ebs_burst_balance_average < 50
+  #      for: 10m
+  #      labels:
+  #        severity: warning
+  #    - alert: ELB-Low-BurstBalance
+  #      annotations:
+  #        message: The ELB BurstBalance during the last 10 minutes is lower than 30%.
+  #      expr: aws_ebs_burst_balance_average < 30
+  #      for: 10m
+  #      labels:
+  #        severity: critical
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+
+  # pathType is only for k8s >= 1.18
+  pathType: Prefix
+
+securityContext:
+  runAsUser: 65534  # run as nobody user instead of root
+  fsGroup: 65534  # necessary to be able to read the EKS IAM token
+
+containerSecurityContext: {}
+  # allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem: true
+
+# Leverage a PriorityClass to ensure your pods survive resource shortages
+# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# priorityClassName: system-cluster-critical
+priorityClassName: ""

--- a/addons/prometheus-cloudwatch-exporter/locals.tf
+++ b/addons/prometheus-cloudwatch-exporter/locals.tf
@@ -39,6 +39,6 @@ locals {
     var.helm_config
   )
 
-  role_name   = try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "${local.name}-${var.eks_cluster_name}-role")
+  role_name   = coalesce(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "${local.name}-${var.eks_cluster_name}-role")
   policy_name = "${local.name}-${var.eks_cluster_name}-policy"
 }

--- a/addons/prometheus-cloudwatch-exporter/locals.tf
+++ b/addons/prometheus-cloudwatch-exporter/locals.tf
@@ -1,0 +1,44 @@
+locals {
+  name = "prometheus-cloudwatch-exporter"
+
+  default_helm_config = {
+    name                       = try(var.prometheus_cloudwatch_exporter_extra_configs.name, local.name)
+    chart                      = try(var.prometheus_cloudwatch_exporter_extra_configs.chart, local.name)
+    repository                 = try(var.prometheus_cloudwatch_exporter_extra_configs.repository, "https://prometheus-community.github.io/helm-charts")
+    version                    = try(var.prometheus_cloudwatch_exporter_extra_configs.version, "0.25.2")
+    namespace                  = try(var.prometheus_cloudwatch_exporter_extra_configs.namespace, "monitoring")
+    create_namespace           = try(var.prometheus_cloudwatch_exporter_extra_configs.create_namespace, true)
+    description                = "Prometheus Cloudwatch-Exporter helm Chart deployment configuration"
+    timeout                    = try(var.prometheus_cloudwatch_exporter_extra_configs.timeout, "600")
+    lint                       = try(var.prometheus_cloudwatch_exporter_extra_configs.lint, "false")
+    repository_key_file        = try(var.prometheus_cloudwatch_exporter_extra_configs.repository_key_file, "")
+    repository_cert_file       = try(var.prometheus_cloudwatch_exporter_extra_configs.repository_cert_file, "")
+    repository_username        = try(var.prometheus_cloudwatch_exporter_extra_configs.repository_username, "")
+    repository_password        = try(var.prometheus_cloudwatch_exporter_extra_configs.repository_password, "")
+    verify                     = try(var.prometheus_cloudwatch_exporter_extra_configs.verify, "false")
+    keyring                    = try(var.prometheus_cloudwatch_exporter_extra_configs.keyring, "")
+    disable_webhooks           = try(var.prometheus_cloudwatch_exporter_extra_configs.disable_webhooks, "false")
+    reuse_values               = try(var.prometheus_cloudwatch_exporter_extra_configs.reuse_values, "false")
+    reset_values               = try(var.prometheus_cloudwatch_exporter_extra_configs.reset_values, "false")
+    force_update               = try(var.prometheus_cloudwatch_exporter_extra_configs.force_update, "false")
+    recreate_pods              = try(var.prometheus_cloudwatch_exporter_extra_configs.recreate_pods, "false")
+    cleanup_on_fail            = try(var.prometheus_cloudwatch_exporter_extra_configs.cleanup_on_fail, "false")
+    max_history                = try(var.prometheus_cloudwatch_exporter_extra_configs.max_history, "0")
+    atomic                     = try(var.prometheus_cloudwatch_exporter_extra_configs.atomic, "false")
+    skip_crds                  = try(var.prometheus_cloudwatch_exporter_extra_configs.skip_crds, "false")
+    render_subchart_notes      = try(var.prometheus_cloudwatch_exporter_extra_configs.render_subchart_notes, "true")
+    disable_openapi_validation = try(var.prometheus_cloudwatch_exporter_extra_configs.disable_openapi_validation, "false")
+    wait                       = try(var.prometheus_cloudwatch_exporter_extra_configs.wait, "true")
+    wait_for_jobs              = try(var.prometheus_cloudwatch_exporter_extra_configs.wait_for_jobs, "false")
+    dependency_update          = try(var.prometheus_cloudwatch_exporter_extra_configs.dependency_update, "false")
+    replace                    = try(var.prometheus_cloudwatch_exporter_extra_configs.replace, "false")
+  }
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+
+  role_name   = try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "${local.name}-${var.eks_cluster_name}-role")
+  policy_name = "${local.name}-${var.eks_cluster_name}-policy"
+}

--- a/addons/prometheus-cloudwatch-exporter/main.tf
+++ b/addons/prometheus-cloudwatch-exporter/main.tf
@@ -17,7 +17,7 @@ module "prometheus_cloudwatch_exporter_secret" {
 }
 
 module "prometheus_cloudwatch_exporter_role" {
-  count = var.secret_manifest == [] && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
+  count  = var.secret_manifest == [] && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
   source = "../helm"
 
   manage_via_gitops = var.manage_via_gitops

--- a/addons/prometheus-cloudwatch-exporter/main.tf
+++ b/addons/prometheus-cloudwatch-exporter/main.tf
@@ -1,0 +1,131 @@
+module "prometheus_cloudwatch_exporter_secret" {
+  count  = length(var.secret_manifest)
+  source = "../helm"
+
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.helm_config
+  addon_context     = var.addon_context
+
+  set_values = [
+    {
+      name  = "aws.secret.name"
+      value = "aws"
+    }
+  ]
+
+  depends_on = [resource.kubectl_manifest.secret_manifest]
+}
+
+module "prometheus_cloudwatch_exporter_role" {
+  # count  = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
+  count  = var.secret_manifest == [] ? 1 : 0
+  source = "../helm"
+
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.helm_config
+  addon_context     = var.addon_context
+
+  set_values = [
+    {
+      name  = "aws.role"
+      value = local.role_name
+    }
+  ]
+
+  depends_on = [resource.kubectl_manifest.secret_manifest]
+}
+
+# Secret for AWS Authentication with cloudwatch exporter
+resource "kubectl_manifest" "secret_manifest" {
+  count     = length(var.secret_manifest)
+  yaml_body = file(var.secret_manifest[count.index])
+}
+
+# Role for AWS Authentication
+data "aws_iam_policy_document" "role" {
+  # count = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
+  count = var.secret_manifest == [] ? 1 : 0
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "role" {
+  # count              = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
+  count              = var.secret_manifest == [] ? 1 : 0
+  name               = local.role_name
+  assume_role_policy = data.aws_iam_policy_document.role[0].json
+}
+
+# Policy of the Role
+resource "aws_iam_policy" "policy" {
+  # count       = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
+  count       = var.secret_manifest == [] ? 1 : 0
+  name        = local.policy_name
+  path        = "/"
+  description = "IAM Policy used by ${local.name}-${var.eks_cluster_name} IAM Role"
+  policy      = var.iampolicy_json_content != null ? var.iampolicy_json_content : <<-EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowReadingMetricsFromCloudWatch",
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:DescribeAlarmsForMetric",
+                "cloudwatch:DescribeAlarmHistory",
+                "cloudwatch:DescribeAlarms",
+                "cloudwatch:ListMetrics",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:GetInsightRuleReport",
+                "cloudwatch:GetMetricStatistics"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AllowReadingLogsFromCloudWatch",
+            "Effect": "Allow",
+            "Action": [
+                "logs:DescribeLogGroups",
+                "logs:GetLogGroupFields",
+                "logs:StartQuery",
+                "logs:StopQuery",
+                "logs:GetQueryResults",
+                "logs:GetLogEvents"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AllowReadingTagsInstancesRegionsFromEC2",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+                "ec2:DescribeRegions"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AllowReadingResourcesForTags",
+            "Effect": "Allow",
+            "Action": "tag:GetResources",
+            "Resource": "*"
+        }
+    ]
+}
+EOT
+}
+
+# Policy Attachment with Role
+resource "aws_iam_role_policy_attachment" "prometheus_cloudwatch_exporter_policy" {
+  # count      = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
+  count      = var.secret_manifest == [] ? 1 : 0
+  policy_arn = aws_iam_policy.policy[0].arn
+  role       = aws_iam_role.role[0].name
+}

--- a/addons/prometheus-cloudwatch-exporter/main.tf
+++ b/addons/prometheus-cloudwatch-exporter/main.tf
@@ -17,8 +17,7 @@ module "prometheus_cloudwatch_exporter_secret" {
 }
 
 module "prometheus_cloudwatch_exporter_role" {
-  count  = var.secret_manifest == [] && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
-  # count  = var.secret_manifest == [] ? 1 : 0
+  count = var.secret_manifest == [] && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
   source = "../helm"
 
   manage_via_gitops = var.manage_via_gitops
@@ -42,7 +41,7 @@ resource "kubectl_manifest" "secret_manifest" {
 
 # Role for AWS Authentication
 data "aws_iam_policy_document" "role" {
-  count  = length(var.secret_manifest) == 0 && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
+  count = length(var.secret_manifest) == 0 && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]

--- a/addons/prometheus-cloudwatch-exporter/main.tf
+++ b/addons/prometheus-cloudwatch-exporter/main.tf
@@ -13,12 +13,12 @@ module "prometheus_cloudwatch_exporter_secret" {
     }
   ]
 
-  depends_on = [resource.kubectl_manifest.secret_manifest]
+  depends_on = [kubectl_manifest.secret_manifest]
 }
 
 module "prometheus_cloudwatch_exporter_role" {
-  # count  = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
-  count  = var.secret_manifest == [] ? 1 : 0
+  count  = var.secret_manifest == [] && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
+  # count  = var.secret_manifest == [] ? 1 : 0
   source = "../helm"
 
   manage_via_gitops = var.manage_via_gitops
@@ -31,8 +31,7 @@ module "prometheus_cloudwatch_exporter_role" {
       value = local.role_name
     }
   ]
-
-  depends_on = [resource.kubectl_manifest.secret_manifest]
+  depends_on = [kubectl_manifest.secret_manifest]
 }
 
 # Secret for AWS Authentication with cloudwatch exporter
@@ -43,8 +42,7 @@ resource "kubectl_manifest" "secret_manifest" {
 
 # Role for AWS Authentication
 data "aws_iam_policy_document" "role" {
-  # count = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
-  count = var.secret_manifest == [] ? 1 : 0
+  count  = length(var.secret_manifest) == 0 && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -57,16 +55,14 @@ data "aws_iam_policy_document" "role" {
 }
 
 resource "aws_iam_role" "role" {
-  # count              = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
-  count              = var.secret_manifest == [] ? 1 : 0
+  count              = length(var.secret_manifest) == 0 && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
   name               = local.role_name
   assume_role_policy = data.aws_iam_policy_document.role[0].json
 }
 
 # Policy of the Role
 resource "aws_iam_policy" "policy" {
-  # count       = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
-  count       = var.secret_manifest == [] ? 1 : 0
+  count       = length(var.secret_manifest) == 0 && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
   name        = local.policy_name
   path        = "/"
   description = "IAM Policy used by ${local.name}-${var.eks_cluster_name} IAM Role"
@@ -124,8 +120,7 @@ EOT
 
 # Policy Attachment with Role
 resource "aws_iam_role_policy_attachment" "prometheus_cloudwatch_exporter_policy" {
-  # count      = var.secret_manifest == [] && try(var.prometheus_cloudwatch_exporter_extra_configs.role_name, "") != "" ? 1 : 0
-  count      = var.secret_manifest == [] ? 1 : 0
+  count      = length(var.secret_manifest) == 0 && var.prometheus_cloudwatch_exporter_extra_configs.role_name == "" ? 1 : 0
   policy_arn = aws_iam_policy.policy[0].arn
   role       = aws_iam_role.role[0].name
 }

--- a/addons/prometheus-cloudwatch-exporter/main.tf
+++ b/addons/prometheus-cloudwatch-exporter/main.tf
@@ -30,13 +30,20 @@ module "prometheus_cloudwatch_exporter_role" {
       value = local.role_name
     }
   ]
-  depends_on = [kubectl_manifest.secret_manifest]
+  depends_on = [module.prometheus_cloudwatch_exporter_secret]
+}
+
+resource "kubernetes_namespace" "prometheus_cloudwatch_exporter_namespace" {
+  metadata {
+    name = local.default_helm_config.namespace
+  }
 }
 
 # Secret for AWS Authentication with cloudwatch exporter
 resource "kubectl_manifest" "secret_manifest" {
-  count     = length(var.secret_manifest)
-  yaml_body = file(var.secret_manifest[count.index])
+  count      = length(var.secret_manifest)
+  yaml_body  = file(var.secret_manifest[count.index])
+  depends_on = [kubernetes_namespace.prometheus_cloudwatch_exporter_namespace]
 }
 
 # Role for AWS Authentication

--- a/addons/prometheus-cloudwatch-exporter/outputs.tf
+++ b/addons/prometheus-cloudwatch-exporter/outputs.tf
@@ -1,0 +1,11 @@
+output "namespace" {
+  value = local.default_helm_config.namespace
+}
+
+output "chart_version" {
+  value = local.default_helm_config.version
+}
+
+output "repository" {
+  value = local.default_helm_config.repository
+}

--- a/addons/prometheus-cloudwatch-exporter/variables.tf
+++ b/addons/prometheus-cloudwatch-exporter/variables.tf
@@ -28,7 +28,9 @@ variable "addon_context" {
 variable "prometheus_cloudwatch_exporter_extra_configs" {
   description = "Override attributes of helm_release terraform resource"
   type        = any
-  default     = {}
+  default     = {
+    role_name = null
+  }
 }
 
 variable "secret_manifest" {

--- a/addons/prometheus-cloudwatch-exporter/variables.tf
+++ b/addons/prometheus-cloudwatch-exporter/variables.tf
@@ -28,7 +28,7 @@ variable "addon_context" {
 variable "prometheus_cloudwatch_exporter_extra_configs" {
   description = "Override attributes of helm_release terraform resource"
   type        = any
-  default     = {
+  default = {
     role_name = null
   }
 }

--- a/addons/prometheus-cloudwatch-exporter/variables.tf
+++ b/addons/prometheus-cloudwatch-exporter/variables.tf
@@ -1,0 +1,49 @@
+variable "helm_config" {
+  description = "Helm provider config for Prometheus Cloudwatch Exporter"
+  type        = any
+  default     = {}
+}
+
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps"
+  type        = bool
+  default     = false
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+  })
+}
+
+variable "prometheus_cloudwatch_exporter_extra_configs" {
+  description = "Override attributes of helm_release terraform resource"
+  type        = any
+  default     = {}
+}
+
+variable "secret_manifest" {
+  description = "Path of Ingress and Gateway yaml manifests"
+  type        = list(any)
+  default     = []
+}
+
+variable "eks_cluster_name" {
+  type    = string
+  default = ""
+}
+
+variable "iampolicy_json_content" {
+  description = "Custom IAM Policy for Prometheus Cloudwatch Exporter's Role"
+  type        = string
+  default     = null
+}

--- a/addons/prometheus-cloudwatch-exporter/versions.tf
+++ b/addons/prometheus-cloudwatch-exporter/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.23"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.29"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.13.0"
+    }
+  }
+}

--- a/addons/reloader/README.md
+++ b/addons/reloader/README.md
@@ -5,7 +5,7 @@ Reloader manages the following AWS resources
 
 ## Installation
 Below terraform script shows how to use Reloader Terraform Addon, A complete example is also given [here](https://github.com/clouddrove/terraform-helm-eks-addons/blob/master/_examples/complete/main.tf).
-```bash
+```hcl
 module "addons" {
   source  = "clouddrove/eks-addons/aws"
   version = "0.1.0"

--- a/main.tf
+++ b/main.tf
@@ -247,3 +247,15 @@ module "actions_runner_controller" {
   addon_context                           = local.addon_context
   actions_runner_controller_extra_configs = var.actions_runner_controller_extra_configs
 }
+
+module "prometheus_cloudwatch_exporter" {
+  count                                        = var.prometheus_cloudwatch_exporter ? 1 : 0
+  source                                       = "./addons/prometheus-cloudwatch-exporter"
+  helm_config                                  = var.prometheus_cloudwatch_exporter_helm_config != null ? var.prometheus_cloudwatch_exporter_helm_config : { values = [local_file.prometheus_cloudwatch_exporter_helm_config[count.index].content] }
+  manage_via_gitops                            = var.manage_via_gitops
+  addon_context                                = local.addon_context
+  prometheus_cloudwatch_exporter_extra_configs = var.prometheus_cloudwatch_exporter_extra_configs
+  secret_manifest                              = var.prometheus_cloudwatch_exporter_secret_manifest
+  eks_cluster_name                             = data.aws_eks_cluster.eks_cluster.name
+  iampolicy_json_content                       = var.prometheus_cloudwatch_exporter_role_iampolicy_json_content
+}

--- a/override_values.tf
+++ b/override_values.tf
@@ -836,3 +836,30 @@ resources:
   EOT
   filename = "${path.module}/override_values/actions_runner_controller.yaml"
 }
+
+#-----------PROMETHEUS-CLOUDWATCH-EXPORTER--------------------
+resource "local_file" "prometheus_cloudwatch_exporter_helm_config" {
+  count    = var.prometheus_cloudwatch_exporter && (var.prometheus_cloudwatch_exporter_helm_config == null) ? 1 : 0
+  content  = <<EOT
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: "eks.amazonaws.com/nodegroup"
+          operator: In
+          values:
+          - "critical"
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 250Mi
+  requests:
+    cpu: 50m
+    memory: 150Mi
+
+  EOT
+  filename = "${path.module}/override_values/prometheus_cloudwatch_exporter.yaml"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -584,7 +584,9 @@ variable "prometheus_cloudwatch_exporter_helm_config" {
 variable "prometheus_cloudwatch_exporter_extra_configs" {
   description = "Override attributes of helm_release terraform resource"
   type        = any
-  default     = {}
+  default     = {
+    role_name = ""
+  }
 }
 
 variable "prometheus_cloudwatch_exporter_secret_manifest" {

--- a/variables.tf
+++ b/variables.tf
@@ -567,3 +567,34 @@ variable "actions_runner_controller_extra_configs" {
   type        = any
   default     = {}
 }
+
+#-----------PROMETHEUS CLOUDWATCH EXPORTER----------------------
+variable "prometheus_cloudwatch_exporter" {
+  description = "Enable Prometheus Cloudwatch Exporter add-on"
+  type        = bool
+  default     = false
+}
+
+variable "prometheus_cloudwatch_exporter_helm_config" {
+  description = "Path to override-values.yaml for Promtheus Cloudwatch Exporter Chart"
+  type        = any
+  default     = null
+}
+
+variable "prometheus_cloudwatch_exporter_extra_configs" {
+  description = "Override attributes of helm_release terraform resource"
+  type        = any
+  default     = {}
+}
+
+variable "prometheus_cloudwatch_exporter_secret_manifest" {
+  description = "Path of Ingress and Gateway yaml manifests"
+  type        = list(any)
+  default     = []
+}
+
+variable "prometheus_cloudwatch_exporter_role_iampolicy_json_content" {
+  description = "Custom IAM Policy for Prometheus Cloudwatch Exporter's Role"
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -584,7 +584,7 @@ variable "prometheus_cloudwatch_exporter_helm_config" {
 variable "prometheus_cloudwatch_exporter_extra_configs" {
   description = "Override attributes of helm_release terraform resource"
   type        = any
-  default     = {
+  default = {
     role_name = ""
   }
 }


### PR DESCRIPTION
# Don't merge this before [this](https://github.com/clouddrove/terraform-aws-eks-addons/pull/48) PR. 
# [PR-#48](https://github.com/clouddrove/terraform-aws-eks-addons/pull/48) should be merged in top priority

## what
* Described prerequisites before Cluster autoscaler setup in kubernetes cluster.
* Adedd tags in kubernetes node groups as far as cluster autoscaler is true in complete example.

## why
* ASG tagging is required to enable Discovery for Cluster autoscaler.
* Auto-discovery finds ASGs tags as below and automatically manages them based on the min and max size specified in the ASG.

## references
* https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler