### PR TITLE
Fix: not authorized to perform ec2 DescribeLaunchTemplateVersions

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -9,7 +9,9 @@ jobs:
     uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
     with:
       working_directory: './examples/complete/'
+      provider: aws
   tf-checks-basic-example:
     uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
     with:
       working_directory: './examples/basic/'
+      provider: aws

--- a/addons/cluster-autoscaler/main.tf
+++ b/addons/cluster-autoscaler/main.tf
@@ -55,7 +55,7 @@ resource "aws_iam_policy" "policy" {
             "Effect": "Allow",
             "Resource": "*"
         }
-    ]
+    ],
     "Version": "2012-10-17"
 }  
   EOT

--- a/addons/cluster-autoscaler/main.tf
+++ b/addons/cluster-autoscaler/main.tf
@@ -50,7 +50,7 @@ resource "aws_iam_policy" "policy" {
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup",
                 "elasticloadbalancing:DescribeLoadBalancers",
-                "ec2:DescribeLaunchTemplateVersions",
+                "ec2:DescribeLaunchTemplateVersions"
             ],
             "Effect": "Allow",
             "Resource": "*"

--- a/addons/cluster-autoscaler/main.tf
+++ b/addons/cluster-autoscaler/main.tf
@@ -55,7 +55,7 @@ resource "aws_iam_policy" "policy" {
             "Effect": "Allow",
             "Resource": "*"
         }
-    ],
+    ]
     "Version": "2012-10-17"
 }  
   EOT

--- a/addons/cluster-autoscaler/main.tf
+++ b/addons/cluster-autoscaler/main.tf
@@ -49,7 +49,8 @@ resource "aws_iam_policy" "policy" {
                 "eks:Describe*",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup",
-                "elasticloadbalancing:DescribeLoadBalancers"
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "ec2:DescribeLaunchTemplateVersions",
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
## what
* Added ec2:DescribeLaunchTemplateVersions permission to autoscaler to avoid below error 
```
not authorized to perform: ec2:DescribeLaunchTemplateVersions because no identity-based policy allows the ec2:DescribeLaunchTemplateVersions action
```
![Screenshot from 2024-07-08 22-58-00 (1)](https://github.com/clouddrove/terraform-aws-eks-addons/assets/78293616/02c0d375-0d05-457d-b1bc-55e2c5ddfb21)

