### PR TITLE
Feat/vpc id and region aws load balancer controller

### DIFF
--- a/addons/aws-load-balancer-controller/data.tf
+++ b/addons/aws-load-balancer-controller/data.tf
@@ -2,3 +2,4 @@ data "aws_eks_cluster" "eks_cluster" {
   # this makes downstream resources wait for data plane to be ready
   name = var.eks_cluster_name
 }
+data "aws_region" "current" {}

--- a/addons/aws-load-balancer-controller/main.tf
+++ b/addons/aws-load-balancer-controller/main.tf
@@ -27,11 +27,11 @@ module "helm_addon" {
       value = "${local.name}-sa"
     },
     {
-      name = "vpc.id"
+      name  = "vpc.id"
       value = data.aws_eks_cluster.eks_cluster.vpc_config[0].vpc_id
     },
     {
-      name = "region.name"
+      name  = "region.name"
       value = data.aws_region.current.name
     }
   ]

--- a/addons/aws-load-balancer-controller/main.tf
+++ b/addons/aws-load-balancer-controller/main.tf
@@ -25,6 +25,14 @@ module "helm_addon" {
     {
       name  = "node.serviceAccount.name"
       value = "${local.name}-sa"
+    },
+    {
+      name = "vpc.id"
+      value = data.aws_eks_cluster.eks_cluster.vpc_config[0].vpc_id
+    },
+    {
+      name = "region.name"
+      value = data.aws_region.current.name
     }
   ]
 


### PR DESCRIPTION
## what
* Set values of region and vpc_id dynamically in aws-load-balancer-controller addon module

## why
* To fetch the value automatically without having to hardcode value every time