### PR TITLE
chore(terraform): bump to 1.14.5

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
 
   tf-checks-complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.1
     with:
       working_directory: './examples/complete/'
       provider: aws
@@ -18,7 +18,7 @@ jobs:
       BUILD_ROLE: ${{ secrets.BUILD_ROLE }}
 
   tf-checks-basic-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.1
     with:
       working_directory: './examples/basic/'
       provider: aws

--- a/addons/actions-runner-controller/versions.tf
+++ b/addons/actions-runner-controller/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/aws-ebs-csi-driver/versions.tf
+++ b/addons/aws-ebs-csi-driver/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/aws-efs-csi-driver/versions.tf
+++ b/addons/aws-efs-csi-driver/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/aws-load-balancer-controller/versions.tf
+++ b/addons/aws-load-balancer-controller/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/aws-node-termination-handler/versions.tf
+++ b/addons/aws-node-termination-handler/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/aws-xray/version.tf
+++ b/addons/aws-xray/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/calico-tigera/versions.tf
+++ b/addons/calico-tigera/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/cert-manager/versions.tf
+++ b/addons/cert-manager/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/cluster-autoscaler/versions.tf
+++ b/addons/cluster-autoscaler/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/external-dns/versions.tf
+++ b/addons/external-dns/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/external-secrets/versions.tf
+++ b/addons/external-secrets/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/filebeat/versions.tf
+++ b/addons/filebeat/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/fluent-bit/versions.tf
+++ b/addons/fluent-bit/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/grafana/version.tf
+++ b/addons/grafana/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/helm/versions.tf
+++ b/addons/helm/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     helm = {

--- a/addons/ingress-nginx/versions.tf
+++ b/addons/ingress-nginx/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/istio-ingress/versions.tf
+++ b/addons/istio-ingress/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/jaeger/versions.tf
+++ b/addons/jaeger/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/k8s-pod-restart-info-collector/versions.tf
+++ b/addons/k8s-pod-restart-info-collector/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/karpenter/versions.tf
+++ b/addons/karpenter/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/keda/versions.tf
+++ b/addons/keda/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/kiali-server/versions.tf
+++ b/addons/kiali-server/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/kube-state-metrics/versions.tf
+++ b/addons/kube-state-metrics/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/kubeclarity/versions.tf
+++ b/addons/kubeclarity/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/loki/versions.tf
+++ b/addons/loki/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/metrics-server/versions.tf
+++ b/addons/metrics-server/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/nri-bundle/versions.tf
+++ b/addons/nri-bundle/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/prometheus-cloudwatch-exporter/versions.tf
+++ b/addons/prometheus-cloudwatch-exporter/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/prometheus/version.tf
+++ b/addons/prometheus/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/redis/versions.tf
+++ b/addons/redis/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/reloader/versions.tf
+++ b/addons/reloader/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/addons/velero/versions.tf
+++ b/addons/velero/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     kubernetes = {

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.4"
+  required_version = ">= 1.14.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/external-eks/versions.tf
+++ b/examples/external-eks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/irsa/versions.tf
+++ b/modules/irsa/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.14.5"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- bump Terraform `required_version` constraints to `>= 1.14.5` where defined
- align Terraform CI version references to `1.14.5` where applicable

## Validation
- CI checks run on this PR
